### PR TITLE
Improve UX, responsive layout, JSON viewer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Assemble site
         run: |
           mkdir -p _site
-          cp dist/app.js dist/app.css pages/index.html _site/
+          cp build/app.js build/app.css pages/index.html _site/
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ is typically embedded via [vmkteam/zenrpc](https://github.com/vmkteam/zenrpc).
 - **Docs** — one flat parameter table with nested types expanded inline (collapsible), a type badge and required mark per field, enum values, output type and error codes.
 - **Try it out** — an auto-generated form with type-based placeholders, or a raw JSON editor with syntax highlighting; paste a `curl` command to build the request; submit with Cmd/Ctrl+Enter.
 - **Calls** — live JSON-RPC requests with cancel and timeout; response timing and size.
-- **Response** — interactive collapsible tree and highlighted raw view, full-text filter, line wrap, fullscreen, copy, download, in-place edit (for mocks), and clickable links for id fields (configurable). Save responses for later.
+- **Response** — interactive tree (expand/collapse all, expansion kept across re-runs) and highlighted raw view, full-text filter, line wrap, fullscreen, copy, download, in-place edit (for mocks), and clickable links for id fields (configurable). Save responses for later.
 - **Errors** — full JSON-RPC error (code, message, data) shown in the same result panel.
 - **Reuse** — export a request as curl, share a deep link with parameters, save / reorder / rename requests, and re-run them from history.
 - **Environments** — save named configuration snapshots (endpoint / schema / headers) you can rename and switch between; the navbar recolors per environment (DEV/PROD presets or a custom color) so they are easy to tell apart.

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ is typically embedded via [vmkteam/zenrpc](https://github.com/vmkteam/zenrpc).
 
 ## Features
 
-- **Schemas** — load SMD or OpenRPC by URL; the format is auto-detected. Add custom request headers.
-- **Browse** — searchable method sidebar with favorites, recent calls, collapsible namespaces and keyboard navigation.
-- **Docs** — per-method input parameters, output type and error codes, including nested type definitions.
-- **Try it out** — an auto-generated form (from the schema) or a raw JSON editor with syntax highlighting; submit with Cmd/Ctrl+Enter.
+- **Schemas** — load SMD or OpenRPC by URL; the format is auto-detected. Add custom request headers, pick a host-provided preset, or import a config to skip setup.
+- **Browse** — searchable method sidebar (sticky search) with favorites, recent calls, collapsible namespaces (persisted) and keyboard navigation.
+- **Docs** — one flat parameter table with nested types expanded inline (collapsible), a type badge and required mark per field, enum values, output type and error codes.
+- **Try it out** — an auto-generated form with type-based placeholders, or a raw JSON editor with syntax highlighting; paste a `curl` command to build the request; submit with Cmd/Ctrl+Enter.
 - **Calls** — live JSON-RPC requests with cancel and timeout; response timing and size.
-- **Response** — interactive collapsible tree and highlighted raw view, full-text filter, line wrap, fullscreen, copy and download.
+- **Response** — interactive collapsible tree and highlighted raw view, full-text filter, line wrap, fullscreen, copy, download, in-place edit (for mocks), and clickable links for id fields (configurable). Save responses for later.
 - **Errors** — full JSON-RPC error (code, message, data) shown in the same result panel.
-- **Reuse** — export a request as curl, share a deep link with parameters, save requests, and re-run them from history.
-- **Environments** — save named configuration snapshots (endpoint / schema / headers) and switch between them.
-- **Config** — import/export the whole setup (connection, favorites, saved requests, environments) as JSON.
-- **Comfort** — light/dark theme (Steel palette), state persisted to IndexedDB, reduced-motion friendly.
+- **Reuse** — export a request as curl, share a deep link with parameters, save / reorder / rename requests, and re-run them from history.
+- **Environments** — save named configuration snapshots (endpoint / schema / headers) you can rename and switch between; the navbar recolors per environment (DEV/PROD presets or a custom color) so they are easy to tell apart.
+- **Config** — import/export the whole setup (connection, favorites, saved requests & responses, environments, id-link rules, theme & colors) as JSON.
+- **Comfort** — light/dark theme (Steel palette), responsive layout (the toolbar collapses to icons on narrow screens), state persisted to IndexedDB, reduced-motion friendly, optional knowledge-base link.
 
 ## Integration
 
@@ -37,6 +37,13 @@ The integration contract is unchanged — load the bundle and initialize:
     smdUrl: '/rpc/?smd',          // SMD or OpenRPC schema url
     endpoint: '/rpc/',            // RPC endpoint (derived from the schema if omitted)
     headers: {},                  // headers added to every request
+    docsUrl: '',                  // optional knowledge-base link on the setup screen
+    idLinks: {                    // turn id values in responses into links ({id} placeholder)
+      productId: 'https://example.com/product/{id}',
+    },
+    presets: [                    // one-click connections offered on the setup screen
+      { name: 'Prod', smdUrl: 'https://api.example.com/rpc/?smd' },
+    ],
   });
 </script>
 ```
@@ -60,15 +67,16 @@ Requires Node ≥ 20.
 ```bash
 npm install
 npm run dev          # Vite dev server (see index.html)
-npm run build        # type-check + build single bundle into dist/
+npm run build        # type-check + build the single bundle into build/
 npm run typecheck    # tsc --noEmit
 npm run lint         # ESLint
 npm run test         # Vitest unit tests
 npm run test:e2e     # Playwright smoke test (records a video)
 ```
 
-> `npm run build` overwrites the committed legacy `dist/`. Restore it with
-> `git checkout -- dist` after building locally — the v2 bundle ships via Pages.
+> `npm run build` writes to `build/` (gitignored); the committed `dist/` is the
+> frozen legacy bundle and is never touched by the build. CI publishes Pages
+> from `build/`.
 
 ## Layout
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 
 export default [
-  { ignores: ['dist', 'node_modules'] },
+  { ignores: ['dist', 'build', 'node_modules'] },
   js.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smdbox",
-  "version": "2.0.0-dev",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smdbox",
-      "version": "2.0.0-dev",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@rjsf/core": "^6.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smdbox",
-  "version": "2.0.0-dev",
+  "version": "2.1.0",
   "description": "UI for human-readable JSON-RPC SMD schemas: browse methods and call them live.",
   "repository": "https://github.com/vmkteam/smdbox",
   "license": "MIT",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Button,
@@ -18,8 +18,11 @@ import {
   Gear,
   HddStack,
   MoonStars,
+  Pencil,
+  QuestionCircle,
   SunFill,
-  X,
+  Trash,
+  Upload,
   XLg,
 } from 'react-bootstrap-icons';
 
@@ -42,11 +45,24 @@ function Workspace() {
   const activeEnvironmentId = useStore((s) => s.activeEnvironmentId);
   const saveEnvironment = useStore((s) => s.saveEnvironment);
   const applyEnvironment = useStore((s) => s.applyEnvironment);
+  const renameEnvironment = useStore((s) => s.renameEnvironment);
   const deleteEnvironment = useStore((s) => s.deleteEnvironment);
+  const importConfig = useStore((s) => s.importConfig);
+  const docsUrl = useStore((s) => s.docsUrl);
 
   const saveCurrentEnv = () => {
     const name = window.prompt('Environment name:');
     if (name) saveEnvironment(name);
+  };
+  const fileRef = useRef<HTMLInputElement>(null);
+  const loadConfigFile = async (file: File) => {
+    try {
+      const cfg = JSON.parse(await file.text()) as Parameters<typeof importConfig>[0];
+      if (!cfg.smdUrl) return;
+      importConfig(cfg);
+    } catch {
+      // ignore invalid config file
+    }
   };
   const [showSettings, setShowSettings] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
@@ -90,16 +106,30 @@ function Workspace() {
                       className="d-flex justify-content-between align-items-center"
                     >
                       <span>{env.name}</span>
-                      <span
-                        role="button"
-                        aria-label={`Delete ${env.name}`}
-                        className="ms-3 text-danger"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          deleteEnvironment(env.id);
-                        }}
-                      >
-                        <X />
+                      <span className="d-flex align-items-center gap-2 ms-3">
+                        <span
+                          role="button"
+                          aria-label={`Rename ${env.name}`}
+                          className="text-secondary"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            const name = window.prompt('Environment name:', env.name)?.trim();
+                            if (name) renameEnvironment(env.id, name);
+                          }}
+                        >
+                          <Pencil />
+                        </span>
+                        <span
+                          role="button"
+                          aria-label={`Delete ${env.name}`}
+                          className="text-danger"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            deleteEnvironment(env.id);
+                          }}
+                        >
+                          <Trash />
+                        </span>
                       </span>
                     </Dropdown.Item>
                   ))}
@@ -145,6 +175,43 @@ function Workspace() {
             {project.created && (
               <Button size="sm" variant="outline-light" onClick={() => setShowSettings(true)}>
                 <Gear className="me-1" /> Settings
+              </Button>
+            )}
+            {/* Import is for onboarding only; in the working mode use Settings. */}
+            {!project.created && (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline-light"
+                  onClick={() => fileRef.current?.click()}
+                  title="Import config"
+                >
+                  <Upload className="me-1" /> Import
+                </Button>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept="application/json"
+                  hidden
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    if (f) void loadConfigFile(f);
+                    e.target.value = '';
+                  }}
+                />
+              </>
+            )}
+            {docsUrl && (
+              <Button
+                size="sm"
+                variant="outline-light"
+                href={docsUrl}
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Knowledge base"
+                title="Knowledge base"
+              >
+                <QuestionCircle />
               </Button>
             )}
             <Button

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -282,9 +282,9 @@ function Workspace() {
             </Modal.Body>
           </Modal>
 
-          <Modal show={showSaved} onHide={() => setShowSaved(false)}>
+          <Modal show={showSaved} onHide={() => setShowSaved(false)} size="lg">
             <Modal.Header closeButton>
-              <Modal.Title>Saved requests</Modal.Title>
+              <Modal.Title>Saved</Modal.Title>
             </Modal.Header>
             <Modal.Body>
               <Saved onClose={() => setShowSaved(false)} />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,7 +41,11 @@ function Workspace() {
   const clearProject = useStore((s) => s.clearProject);
   const theme = useStore((s) => s.prefs.theme);
   const toggleTheme = useStore((s) => s.toggleTheme);
-  const navbarColor = useStore((s) => s.prefs.navbarColor);
+  // Active env color wins, so switching envs recolors the navbar; else the global pref.
+  const navbarColor = useStore((s) => {
+    const env = s.environments.find((e) => e.id === s.activeEnvironmentId);
+    return (env?.color || s.prefs.navbarColor) ?? '';
+  });
   const environments = useStore((s) => s.environments);
   const activeEnvironmentId = useStore((s) => s.activeEnvironmentId);
   const saveEnvironment = useStore((s) => s.saveEnvironment);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -110,7 +110,6 @@ function Workspace() {
                         <span
                           role="button"
                           aria-label={`Rename ${env.name}`}
-                          className="text-secondary"
                           onClick={(e) => {
                             e.stopPropagation();
                             const name = window.prompt('Environment name:', env.name)?.trim();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -33,7 +33,7 @@ import { Project } from '../components/Project';
 import { Saved } from '../components/Saved';
 import { Sidebar } from '../components/Sidebar';
 import { refreshSmd, useSmd } from '../data/queries';
-import { useStore } from '../store/store';
+import { selectNavbarColor, useStore } from '../store/store';
 import { useMethodHash } from './useMethodHash';
 
 function Workspace() {
@@ -42,10 +42,7 @@ function Workspace() {
   const theme = useStore((s) => s.prefs.theme);
   const toggleTheme = useStore((s) => s.toggleTheme);
   // Active env color wins, so switching envs recolors the navbar; else the global pref.
-  const navbarColor = useStore((s) => {
-    const env = s.environments.find((e) => e.id === s.activeEnvironmentId);
-    return (env?.color || s.prefs.navbarColor) ?? '';
-  });
+  const navbarColor = useStore(selectNavbarColor);
   const environments = useStore((s) => s.environments);
   const activeEnvironmentId = useStore((s) => s.activeEnvironmentId);
   const saveEnvironment = useStore((s) => s.saveEnvironment);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -88,9 +88,11 @@ function Workspace() {
             {/* Group 1 — connection */}
             {(project.created || environments.length > 0) && (
               <Dropdown align="end">
-                <Dropdown.Toggle size="sm" variant="outline-light">
+                <Dropdown.Toggle size="sm" variant="outline-light" title="Environments">
                   <HddStack className="me-1" />{' '}
-                  {environments.find((e) => e.id === activeEnvironmentId)?.name ?? 'Env'}
+                  <span className="sb-nav-label">
+                    {environments.find((e) => e.id === activeEnvironmentId)?.name ?? 'Env'}
+                  </span>
                 </Dropdown.Toggle>
                 <Dropdown.Menu>
                   {environments.length === 0 && (
@@ -142,8 +144,8 @@ function Workspace() {
               </Dropdown>
             )}
             {project.created && (
-              <Button size="sm" variant="outline-light" onClick={clearProject}>
-                <XLg className="me-1" /> Close
+              <Button size="sm" variant="outline-light" onClick={clearProject} title="Close project">
+                <XLg className="me-1" /> <span className="sb-nav-label">Close</span>
               </Button>
             )}
 
@@ -152,18 +154,19 @@ function Workspace() {
             {/* Group 2 — work */}
             {project.created && (
               <ButtonGroup size="sm">
-                <Button variant="outline-light" onClick={() => setShowHistory(true)}>
-                  <ClockHistory className="me-1" /> History
+                <Button variant="outline-light" onClick={() => setShowHistory(true)} title="History">
+                  <ClockHistory className="me-1" /> <span className="sb-nav-label">History</span>
                 </Button>
-                <Button variant="outline-light" onClick={() => setShowSaved(true)}>
-                  <Bookmarks className="me-1" /> Saved
+                <Button variant="outline-light" onClick={() => setShowSaved(true)} title="Saved requests">
+                  <Bookmarks className="me-1" /> <span className="sb-nav-label">Saved</span>
                 </Button>
                 <Button
                   variant="outline-light"
                   onClick={() => refreshSmd(project.smdUrl)}
                   disabled={smd.isFetching}
+                  title="Refresh schema"
                 >
-                  <ArrowClockwise className="me-1" /> Refresh
+                  <ArrowClockwise className="me-1" /> <span className="sb-nav-label">Refresh</span>
                 </Button>
               </ButtonGroup>
             )}
@@ -172,8 +175,8 @@ function Workspace() {
 
             {/* Group 3 — settings */}
             {project.created && (
-              <Button size="sm" variant="outline-light" onClick={() => setShowSettings(true)}>
-                <Gear className="me-1" /> Settings
+              <Button size="sm" variant="outline-light" onClick={() => setShowSettings(true)} title="Project settings">
+                <Gear className="me-1" /> <span className="sb-nav-label">Settings</span>
               </Button>
             )}
             {/* Import is for onboarding only; in the working mode use Settings. */}
@@ -185,7 +188,7 @@ function Workspace() {
                   onClick={() => fileRef.current?.click()}
                   title="Import config"
                 >
-                  <Upload className="me-1" /> Import
+                  <Upload className="me-1" /> <span className="sb-nav-label">Import</span>
                 </Button>
                 <input
                   ref={fileRef}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,6 +41,7 @@ function Workspace() {
   const clearProject = useStore((s) => s.clearProject);
   const theme = useStore((s) => s.prefs.theme);
   const toggleTheme = useStore((s) => s.toggleTheme);
+  const navbarColor = useStore((s) => s.prefs.navbarColor);
   const environments = useStore((s) => s.environments);
   const activeEnvironmentId = useStore((s) => s.activeEnvironmentId);
   const saveEnvironment = useStore((s) => s.saveEnvironment);
@@ -72,6 +73,13 @@ function Workspace() {
   useEffect(() => {
     document.documentElement.setAttribute('data-bs-theme', theme);
   }, [theme]);
+
+  // Override the navbar color (DEV/PROD presets or a custom pick); '' restores the default.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (navbarColor) root.style.setProperty('--sb-navbar-bg', navbarColor);
+    else root.style.removeProperty('--sb-navbar-bg');
+  }, [navbarColor]);
 
   const smd = useSmd(project.created ? project.smdUrl : null, project.headers);
   const services = smd.data?.services;

--- a/src/components/CollapseCaret.tsx
+++ b/src/components/CollapseCaret.tsx
@@ -1,0 +1,24 @@
+import { ChevronDown, ChevronRight } from 'react-bootstrap-icons';
+
+/** Chevron toggle for an inline collapsible row (params table, saved items). */
+export function CollapseCaret({
+  open,
+  onToggle,
+  name,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  name: string;
+}) {
+  return (
+    <button
+      type="button"
+      className="sb-params__caret"
+      aria-expanded={open}
+      aria-label={`${open ? 'Collapse' : 'Expand'} ${name}`}
+      onClick={onToggle}
+    >
+      {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+    </button>
+  );
+}

--- a/src/components/FormFromSchema.tsx
+++ b/src/components/FormFromSchema.tsx
@@ -1,9 +1,15 @@
-import { useRef, type KeyboardEvent } from 'react';
+import { useRef, type ChangeEvent, type FocusEvent, type KeyboardEvent } from 'react';
 import Form from '@rjsf/react-bootstrap';
-import { getTemplate, getUiOptions } from '@rjsf/utils';
-import type { ArrayFieldTemplateProps, IconButtonProps, RJSFSchema } from '@rjsf/utils';
+import { SchemaExamples } from '@rjsf/core';
+import { ariaDescribedByIds, examplesId, getInputProps, getTemplate, getUiOptions } from '@rjsf/utils';
+import type {
+  ArrayFieldTemplateProps,
+  BaseInputTemplateProps,
+  IconButtonProps,
+  RJSFSchema,
+} from '@rjsf/utils';
 import { customizeValidator } from '@rjsf/validator-ajv8';
-import { Button } from 'react-bootstrap';
+import { Button, Form as BsForm } from 'react-bootstrap';
 import { ArrowDown, ArrowUp, PlusLg, Trash } from 'react-bootstrap-icons';
 
 import type { JsonSchema } from '../lib/smdToJsonSchema';
@@ -45,6 +51,77 @@ const buttonTemplates = {
   MoveUpButton: iconButton(ArrowUp, 'Move up', 'outline-secondary'),
   MoveDownButton: iconButton(ArrowDown, 'Move down', 'outline-secondary'),
 };
+
+/** A hint placeholder derived from a field's JSON Schema type/format (D1). */
+function placeholderFor(schema: RJSFSchema): string {
+  const examples = schema.examples;
+  if (Array.isArray(examples) && examples.length) return `e.g. ${String(examples[0])}`;
+  if (schema.default !== undefined && schema.default !== null && typeof schema.default !== 'object') {
+    return `e.g. ${String(schema.default)}`;
+  }
+  switch (schema.format) {
+    case 'date-time':
+      return 'e.g. 2026-01-01T00:00:00Z';
+    case 'date':
+      return 'e.g. 2026-01-01';
+    case 'email':
+      return 'e.g. name@example.com';
+    case 'uri':
+    case 'url':
+      return 'e.g. https://example.com';
+    case 'uuid':
+      return 'e.g. 00000000-0000-0000-0000-000000000000';
+  }
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  switch (type) {
+    case 'integer':
+    case 'number':
+      return 'e.g. 0';
+    case 'string':
+      return 'text';
+    default:
+      return '';
+  }
+}
+
+// Mirrors @rjsf/react-bootstrap's BaseInputTemplate, but fills empty inputs with
+// a type-based example placeholder so fields (incl. fresh "Add item" rows) hint
+// what they expect instead of sitting blank.
+function BaseInputTemplate(props: BaseInputTemplateProps) {
+  const {
+    id, htmlName, placeholder, required, readonly, disabled, type, value,
+    onChange, onChangeOverride, onBlur, onFocus, autofocus, options, schema,
+    rawErrors = [], children, extraProps,
+  } = props;
+  const inputProps = { ...extraProps, ...getInputProps(schema, type, options) };
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) =>
+    onChange(e.target.value === '' ? options.emptyValue : e.target.value);
+  const handleBlur = (e: FocusEvent<HTMLInputElement>) => onBlur(id, e.target.value);
+  const handleFocus = (e: FocusEvent<HTMLInputElement>) => onFocus(id, e.target.value);
+  return (
+    <>
+      <BsForm.Control
+        id={id}
+        name={htmlName || id}
+        placeholder={placeholder || placeholderFor(schema)}
+        autoFocus={autofocus}
+        required={required}
+        disabled={disabled}
+        readOnly={readonly}
+        className={rawErrors.length > 0 ? 'is-invalid' : ''}
+        list={schema.examples ? examplesId(id) : undefined}
+        {...inputProps}
+        value={value || value === 0 ? value : ''}
+        onChange={onChangeOverride || handleChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        aria-describedby={ariaDescribedByIds(id, !!schema.examples)}
+      />
+      {children}
+      <SchemaExamples id={id} schema={schema} />
+    </>
+  );
+}
 
 // The default rjsf-bootstrap array layout squeezes the Add button into a narrow
 // right column. Render items stacked with a normal-width Add button below.
@@ -103,7 +180,7 @@ export function FormFromSchema({ schema, formData, onChange, onSubmit, actions }
         schema={formSchema as RJSFSchema}
         formData={formData}
         validator={validator}
-        templates={{ ButtonTemplates: buttonTemplates, ArrayFieldTemplate }}
+        templates={{ ButtonTemplates: buttonTemplates, ArrayFieldTemplate, BaseInputTemplate }}
         onChange={(e) => onChange(e.formData as Record<string, unknown>)}
         onSubmit={(e) => onSubmit(e.formData as Record<string, unknown>)}
         onError={(errors) => console.error(errors)}

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -12,7 +12,7 @@ import {
 import { JSONTree } from 'react-json-tree';
 
 import { useClipboard } from '../hooks/useClipboard';
-import { idLinkUrl } from '../lib/idLinks';
+import { idLinkUrl, lowerRuleKeys } from '../lib/idLinks';
 import { filterJson } from '../lib/jsonFilter';
 import { highlightJson } from '../lib/jsonHighlight';
 import { useStore } from '../store/store';
@@ -60,10 +60,11 @@ interface TreeProps {
   data: unknown;
   light: boolean;
   expandAll: boolean;
-  idLinks: Record<string, string>;
+  /** Lowercased field -> URL-template rules (see lowerRuleKeys). */
+  idLinkRules: Record<string, string>;
 }
 
-function Tree({ data, light, expandAll, idLinks }: TreeProps) {
+function Tree({ data, light, expandAll, idLinkRules }: TreeProps) {
   if (data === undefined) return <div className="sb-muted">No matches</div>;
   return (
     <JSONTree
@@ -74,7 +75,7 @@ function Tree({ data, light, expandAll, idLinks }: TreeProps) {
       shouldExpandNodeInitially={(_keyPath, _data, level) => expandAll || level < 2}
       // Turn ids into open/copy links when the field matches a configured rule (F1).
       valueRenderer={(display, value, ...keyPath) => {
-        const url = idLinkUrl(keyPath as (string | number)[], value, idLinks);
+        const url = idLinkUrl(keyPath as (string | number)[], value, idLinkRules);
         if (!url) return display as ReactNode;
         return (
           <span className="sb-json-link">
@@ -112,6 +113,7 @@ export function JsonViewer({ json, title = 'Response', error = false, onSave }: 
   const { copied, copy } = useClipboard();
   const light = useStore((s) => s.prefs.theme === 'light');
   const idLinks = useStore((s) => s.idLinks);
+  const idLinkRules = useMemo(() => lowerRuleKeys(idLinks), [idLinks]);
   const [expanded, setExpanded] = useState(false);
   const [query, setQuery] = useState('');
   const [wrap, setWrap] = useState(false);
@@ -196,7 +198,7 @@ export function JsonViewer({ json, title = 'Response', error = false, onSave }: 
         <Tab eventKey="tree" title="Tree">
           {search}
           <div className="sb-json-viewer__tree">
-            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinks={idLinks} />
+            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinkRules={idLinkRules} />
           </div>
         </Tab>
         <Tab eventKey="raw" title="Raw">
@@ -240,7 +242,7 @@ export function JsonViewer({ json, title = 'Response', error = false, onSave }: 
         <Modal.Body>
           {search}
           <div className="sb-json-viewer__tree sb-json-viewer__tree--full">
-            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinks={idLinks} />
+            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinkRules={idLinkRules} />
           </div>
         </Modal.Body>
       </Modal>

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -1,12 +1,21 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Button, Form, Modal, Tab, Tabs } from 'react-bootstrap';
-import { ArrowsAngleExpand, Clipboard, ClipboardCheck, Download } from 'react-bootstrap-icons';
+import {
+  ArrowsAngleExpand,
+  BoxArrowUpRight,
+  Clipboard,
+  ClipboardCheck,
+  Download,
+  Pencil,
+} from 'react-bootstrap-icons';
 import { JSONTree } from 'react-json-tree';
 
 import { useClipboard } from '../hooks/useClipboard';
+import { idLinkUrl } from '../lib/idLinks';
 import { filterJson } from '../lib/jsonFilter';
 import { highlightJson } from '../lib/jsonHighlight';
 import { useStore } from '../store/store';
+import { CodeEditor } from './CodeEditor';
 
 interface JsonViewerProps {
   json: unknown;
@@ -44,7 +53,14 @@ function stringify(json: unknown): string {
   }
 }
 
-function Tree({ data, light, expandAll }: { data: unknown; light: boolean; expandAll: boolean }) {
+interface TreeProps {
+  data: unknown;
+  light: boolean;
+  expandAll: boolean;
+  idLinks: Record<string, string>;
+}
+
+function Tree({ data, light, expandAll, idLinks }: TreeProps) {
   if (data === undefined) return <div className="sb-muted">No matches</div>;
   return (
     <JSONTree
@@ -53,6 +69,37 @@ function Tree({ data, light, expandAll }: { data: unknown; light: boolean; expan
       invertTheme={light}
       hideRoot
       shouldExpandNodeInitially={(_keyPath, _data, level) => expandAll || level < 2}
+      // Turn ids into open/copy links when the field matches a configured rule (F1).
+      valueRenderer={(display, value, ...keyPath) => {
+        const url = idLinkUrl(keyPath as (string | number)[], value, idLinks);
+        if (!url) return display as ReactNode;
+        return (
+          <span className="sb-json-link">
+            <span>{display as ReactNode}</span>
+            <a
+              className="sb-json-link__btn"
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              title={`Open ${url}`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <BoxArrowUpRight />
+            </a>
+            <button
+              type="button"
+              className="sb-json-link__btn"
+              title="Copy link"
+              onClick={(e) => {
+                e.stopPropagation();
+                void navigator.clipboard?.writeText(url);
+              }}
+            >
+              <Clipboard />
+            </button>
+          </span>
+        );
+      }}
     />
   );
 }
@@ -61,16 +108,27 @@ function Tree({ data, light, expandAll }: { data: unknown; light: boolean; expan
 export function JsonViewer({ json, title = 'Response', error = false }: JsonViewerProps) {
   const { copied, copy } = useClipboard();
   const light = useStore((s) => s.prefs.theme === 'light');
+  const idLinks = useStore((s) => s.idLinks);
   const [expanded, setExpanded] = useState(false);
   const [query, setQuery] = useState('');
   const [wrap, setWrap] = useState(false);
+  // E2: local edits to the raw response (for tweaking before reuse as a mock).
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string | null>(null);
 
   const text = useMemo(() => stringify(json), [json]);
+  const shown = draft ?? text;
   const treeData = useMemo(() => filterJson(json, query), [json, query]);
-  const rawHtml = useMemo(() => highlightJson(text), [text]);
+  const rawHtml = useMemo(() => highlightJson(shown), [shown]);
+
+  // A new response discards any local edit.
+  useEffect(() => {
+    setDraft(null);
+    setEditing(false);
+  }, [text]);
 
   const download = () => {
-    const url = URL.createObjectURL(new Blob([text], { type: 'application/json' }));
+    const url = URL.createObjectURL(new Blob([shown], { type: 'application/json' }));
     const a = document.createElement('a');
     a.href = url;
     a.download = `${title.toLowerCase().replace(/\s+/g, '-') || 'response'}.json`;
@@ -81,7 +139,7 @@ export function JsonViewer({ json, title = 'Response', error = false }: JsonView
   // Copy + Download, reused inline and in the expand modal (right-aligned).
   const actionButtons = (
     <>
-      <Button size="sm" variant="outline-secondary" onClick={() => copy(text)}>
+      <Button size="sm" variant="outline-secondary" onClick={() => copy(shown)}>
         {copied ? <ClipboardCheck className="me-1" /> : <Clipboard className="me-1" />}
         {copied ? 'Copied' : 'Copy'}
       </Button>
@@ -130,22 +188,39 @@ export function JsonViewer({ json, title = 'Response', error = false }: JsonView
         <Tab eventKey="tree" title="Tree">
           {search}
           <div className="sb-json-viewer__tree">
-            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} />
+            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinks={idLinks} />
           </div>
         </Tab>
         <Tab eventKey="raw" title="Raw">
-          <Form.Check
-            type="switch"
-            id={`wrap-${title}`}
-            label="Wrap lines"
-            checked={wrap}
-            onChange={(e) => setWrap(e.target.checked)}
-            className="mb-2"
-          />
-          <pre
-            className={`sb-json-code${wrap ? ' sb-json-code--wrap' : ''}`}
-            dangerouslySetInnerHTML={{ __html: rawHtml }}
-          />
+          <div className="sb-json-viewer__rawbar">
+            <Form.Check
+              type="switch"
+              id={`wrap-${title}`}
+              label="Wrap lines"
+              checked={wrap}
+              onChange={(e) => setWrap(e.target.checked)}
+              disabled={editing}
+            />
+            <Button
+              size="sm"
+              variant="outline-secondary"
+              onClick={() => {
+                if (!editing && draft === null) setDraft(text);
+                setEditing((v) => !v);
+              }}
+              title="Edit the response (local only)"
+            >
+              <Pencil className="me-1" /> {editing ? 'Done' : 'Edit'}
+            </Button>
+          </div>
+          {editing ? (
+            <CodeEditor value={draft ?? text} onChange={setDraft} ariaLabel="Edit response JSON" />
+          ) : (
+            <pre
+              className={`sb-json-code${wrap ? ' sb-json-code--wrap' : ''}`}
+              dangerouslySetInnerHTML={{ __html: rawHtml }}
+            />
+          )}
         </Tab>
       </Tabs>
 
@@ -157,7 +232,7 @@ export function JsonViewer({ json, title = 'Response', error = false }: JsonView
         <Modal.Body>
           {search}
           <div className="sb-json-viewer__tree sb-json-viewer__tree--full">
-            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} />
+            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinks={idLinks} />
           </div>
         </Modal.Body>
       </Modal>

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -14,7 +14,7 @@ import {
 import { JSONTree } from 'react-json-tree';
 
 import { useClipboard } from '../hooks/useClipboard';
-import { idLinkUrl, lowerRuleKeys } from '../lib/idLinks';
+import { idLinkUrl, lowerRuleKeys, urlValue } from '../lib/idLinks';
 import { filterJson } from '../lib/jsonFilter';
 import { highlightJson } from '../lib/jsonHighlight';
 import { useStore } from '../store/store';
@@ -80,7 +80,8 @@ function Tree({ data, light, expandAll, expandLevel, idLinkRules }: TreeProps) {
       shouldExpandNodeInitially={(_keyPath, _data, level) => expandAll || level < expandLevel}
       // Turn ids into open/copy links when the field matches a configured rule (F1).
       valueRenderer={(display, value, ...keyPath) => {
-        const url = idLinkUrl(keyPath as (string | number)[], value, idLinkRules);
+        // A configured id rule wins; otherwise link the value if it is itself a URL.
+        const url = idLinkUrl(keyPath as (string | number)[], value, idLinkRules) ?? urlValue(value);
         if (!url) return display as ReactNode;
         return (
           <span className="sb-json-link">

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Button, Form, Modal, Tab, Tabs } from 'react-bootstrap';
 import {
   ArrowsAngleExpand,
+  ArrowsCollapse,
+  ArrowsExpand,
   BookmarkPlus,
   BoxArrowUpRight,
   Clipboard,
@@ -59,12 +61,15 @@ function stringify(json: unknown): string {
 interface TreeProps {
   data: unknown;
   light: boolean;
+  /** Force-expand everything (e.g. while filtering). */
   expandAll: boolean;
+  /** Levels expanded by default (Infinity = expand all, 0 = collapse all). */
+  expandLevel: number;
   /** Lowercased field -> URL-template rules (see lowerRuleKeys). */
   idLinkRules: Record<string, string>;
 }
 
-function Tree({ data, light, expandAll, idLinkRules }: TreeProps) {
+function Tree({ data, light, expandAll, expandLevel, idLinkRules }: TreeProps) {
   if (data === undefined) return <div className="sb-muted">No matches</div>;
   return (
     <JSONTree
@@ -72,7 +77,7 @@ function Tree({ data, light, expandAll, idLinkRules }: TreeProps) {
       theme={TREE_THEME}
       invertTheme={light}
       hideRoot
-      shouldExpandNodeInitially={(_keyPath, _data, level) => expandAll || level < 2}
+      shouldExpandNodeInitially={(_keyPath, _data, level) => expandAll || level < expandLevel}
       // Turn ids into open/copy links when the field matches a configured rule (F1).
       valueRenderer={(display, value, ...keyPath) => {
         const url = idLinkUrl(keyPath as (string | number)[], value, idLinkRules);
@@ -117,6 +122,19 @@ export function JsonViewer({ json, title = 'Response', error = false, onSave }: 
   const [expanded, setExpanded] = useState(false);
   const [query, setQuery] = useState('');
   const [wrap, setWrap] = useState(false);
+  // Expand-all / collapse-all: bump treeKey to remount the tree with a new
+  // default depth; re-runs keep the key (and thus the user's expand state).
+  const [expandMode, setExpandMode] = useState<'all' | 'none' | null>(null);
+  const [treeKey, setTreeKey] = useState(0);
+  const expandLevel = expandMode === 'all' ? Infinity : expandMode === 'none' ? 0 : 2;
+  const expandAllNodes = () => {
+    setExpandMode('all');
+    setTreeKey((k) => k + 1);
+  };
+  const collapseAllNodes = () => {
+    setExpandMode('none');
+    setTreeKey((k) => k + 1);
+  };
   // E2: local edits to the raw response (for tweaking before reuse as a mock).
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<string | null>(null);
@@ -165,15 +183,23 @@ export function JsonViewer({ json, title = 'Response', error = false, onSave }: 
     </>
   );
 
-  const search = (
-    <Form.Control
-      size="sm"
-      className="mb-2"
-      placeholder="Filter response…"
-      value={query}
-      onChange={(e) => setQuery(e.target.value)}
-      aria-label="Filter response"
-    />
+  // Filter input + expand-all/collapse-all, shown above the tree (inline and modal).
+  const treeControls = (
+    <div className="sb-json-viewer__treebar">
+      <Form.Control
+        size="sm"
+        placeholder="Filter response…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Filter response"
+      />
+      <Button size="sm" variant="outline-secondary" onClick={expandAllNodes} aria-label="Expand all" title="Expand all">
+        <ArrowsExpand />
+      </Button>
+      <Button size="sm" variant="outline-secondary" onClick={collapseAllNodes} aria-label="Collapse all" title="Collapse all">
+        <ArrowsCollapse />
+      </Button>
+    </div>
   );
 
   return (
@@ -196,9 +222,16 @@ export function JsonViewer({ json, title = 'Response', error = false, onSave }: 
 
       <Tabs defaultActiveKey="tree" id={`json-viewer-${title}`} className="mb-2">
         <Tab eventKey="tree" title="Tree">
-          {search}
+          {treeControls}
           <div className="sb-json-viewer__tree">
-            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinkRules={idLinkRules} />
+            <Tree
+              key={treeKey}
+              data={treeData}
+              light={light}
+              expandAll={Boolean(query.trim())}
+              expandLevel={expandLevel}
+              idLinkRules={idLinkRules}
+            />
           </div>
         </Tab>
         <Tab eventKey="raw" title="Raw">
@@ -240,9 +273,16 @@ export function JsonViewer({ json, title = 'Response', error = false, onSave }: 
           <span className="sb-json-viewer__actions ms-auto me-2">{actionButtons}</span>
         </Modal.Header>
         <Modal.Body>
-          {search}
+          {treeControls}
           <div className="sb-json-viewer__tree sb-json-viewer__tree--full">
-            <Tree data={treeData} light={light} expandAll={Boolean(query.trim())} idLinkRules={idLinkRules} />
+            <Tree
+              key={treeKey}
+              data={treeData}
+              light={light}
+              expandAll={Boolean(query.trim())}
+              expandLevel={expandLevel}
+              idLinkRules={idLinkRules}
+            />
           </div>
         </Modal.Body>
       </Modal>

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Button, Form, Modal, Tab, Tabs } from 'react-bootstrap';
 import {
   ArrowsAngleExpand,
+  BookmarkPlus,
   BoxArrowUpRight,
   Clipboard,
   ClipboardCheck,
@@ -22,6 +23,8 @@ interface JsonViewerProps {
   title?: string;
   /** Tints the title to flag an error payload. */
   error?: boolean;
+  /** When set, renders a "Save" action (e.g. to store the response). */
+  onSave?: () => void;
 }
 
 // Monokai-ish base16 theme; base00 is transparent so the container bg shows
@@ -105,7 +108,7 @@ function Tree({ data, light, expandAll, idLinks }: TreeProps) {
 }
 
 /** Interactive JSON viewer: searchable tree, highlighted raw, and a fullscreen modal. */
-export function JsonViewer({ json, title = 'Response', error = false }: JsonViewerProps) {
+export function JsonViewer({ json, title = 'Response', error = false, onSave }: JsonViewerProps) {
   const { copied, copy } = useClipboard();
   const light = useStore((s) => s.prefs.theme === 'light');
   const idLinks = useStore((s) => s.idLinks);
@@ -136,9 +139,14 @@ export function JsonViewer({ json, title = 'Response', error = false }: JsonView
     URL.revokeObjectURL(url);
   };
 
-  // Copy + Download, reused inline and in the expand modal (right-aligned).
+  // Copy + Download (+ optional Save), reused inline and in the expand modal.
   const actionButtons = (
     <>
+      {onSave && (
+        <Button size="sm" variant="outline-secondary" onClick={onSave} title="Save this response">
+          <BookmarkPlus className="me-1" /> Save
+        </Button>
+      )}
       <Button size="sm" variant="outline-secondary" onClick={() => copy(shown)}>
         {copied ? <ClipboardCheck className="me-1" /> : <Clipboard className="me-1" />}
         {copied ? 'Copied' : 'Copy'}

--- a/src/components/MethodDescription.tsx
+++ b/src/components/MethodDescription.tsx
@@ -4,7 +4,7 @@ import { CodeChip } from '../design/components/CodeChip';
 import { SectionTitle } from '../design/components/SectionTitle';
 import type { SmdDefinition, SmdJsonSchema, SmdService } from '../types/smd';
 import { ParamsTable } from './ParamsTable';
-import { resolveType, type DescNode } from './paramTypes';
+import { referencedTypeName, resolveType, type DescNode } from './paramTypes';
 
 /** Converts the parameters array into a name->node map for the table. */
 function paramsToProperties(params: SmdJsonSchema[]): Record<string, DescNode> {
@@ -15,20 +15,11 @@ function paramsToProperties(params: SmdJsonSchema[]): Record<string, DescNode> {
   return out;
 }
 
-function DefinitionTables({ definitions }: { definitions?: Record<string, SmdDefinition> }) {
-  if (!definitions) return null;
-  return (
-    <>
-      {Object.entries(definitions).map(([name, def]) => (
-        <div key={name}>
-          <SectionTitle level="subsection">
-            Definition of <CodeChip variant="type">{name}</CodeChip>
-          </SectionTitle>
-          <ParamsTable properties={(def.properties ?? {}) as Record<string, DescNode>} />
-        </div>
-      ))}
-    </>
-  );
+/** Collects definitions from every node into one map, for inline resolution. */
+function mergeDefinitions(nodes: SmdJsonSchema[]): Record<string, SmdDefinition> {
+  const out: Record<string, SmdDefinition> = {};
+  for (const node of nodes) Object.assign(out, node.definitions);
+  return out;
 }
 
 function InputTab({ service }: { service: SmdService }) {
@@ -39,10 +30,7 @@ function InputTab({ service }: { service: SmdService }) {
   return (
     <div>
       <SectionTitle>Parameters</SectionTitle>
-      <ParamsTable properties={properties} />
-      {service.parameters.map((param) => (
-        <DefinitionTables key={param.name ?? ''} definitions={param.definitions} />
-      ))}
+      <ParamsTable properties={properties} definitions={mergeDefinitions(service.parameters)} />
     </div>
   );
 }
@@ -51,10 +39,14 @@ function OutputTab({ returns }: { returns: SmdJsonSchema }) {
   if (!returns.type) {
     return <Alert variant="warning">No output specified in documentation</Alert>;
   }
-  const hasProps = returns.properties && Object.keys(returns.properties).length > 0;
   const typeLabel = resolveType(returns as DescNode);
   // Skip the description when it merely repeats the type name (common for $ref results).
   const desc = returns.description && returns.description !== typeLabel ? returns.description : '';
+  // Properties to expand: inline ones, or those of the referenced definition.
+  const ref = referencedTypeName(returns as DescNode);
+  const refProps = ref ? returns.definitions?.[ref]?.properties : undefined;
+  const props = (returns.properties ?? refProps) as Record<string, DescNode> | undefined;
+  const hasProps = props && Object.keys(props).length > 0;
   return (
     <div>
       <SectionTitle>Returns</SectionTitle>
@@ -77,10 +69,9 @@ function OutputTab({ returns }: { returns: SmdJsonSchema }) {
       {hasProps && (
         <div>
           <SectionTitle level="subsection">Properties of return object</SectionTitle>
-          <ParamsTable properties={returns.properties as Record<string, DescNode>} />
+          <ParamsTable properties={props} definitions={returns.definitions} />
         </div>
       )}
-      <DefinitionTables definitions={returns.definitions} />
     </div>
   );
 }

--- a/src/components/MethodInvoker.tsx
+++ b/src/components/MethodInvoker.tsx
@@ -30,6 +30,7 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
   const prefill = useStore((s) => s.prefill);
   const clearPrefill = useStore((s) => s.clearPrefill);
   const saveRequest = useStore((s) => s.saveRequest);
+  const saveResponse = useStore((s) => s.saveResponse);
   const mutation = useRpc(endpoint, headers);
   const [formData, setFormData] = useState<Record<string, unknown>>({});
   const { copied, copy } = useClipboard();
@@ -218,7 +219,15 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
 
       {showResult && (
         <div className="sb-method-invoker__result">
-          <JsonViewer json={payload} title="Response" error={errored} />
+          <JsonViewer
+            json={payload}
+            title="Response"
+            error={errored}
+            onSave={() => {
+              const name = window.prompt('Save response as:', method);
+              if (name) saveResponse(name, method, payload);
+            }}
+          />
           {meta && (
             <div className="sb-method-invoker__meta">
               {formatDuration(meta.durationMs)} · {formatBytes(meta.size)}

--- a/src/components/MethodInvoker.tsx
+++ b/src/components/MethodInvoker.tsx
@@ -150,45 +150,49 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
         <BookmarkPlus className="me-1" />
         Save
       </Button>
-      <Button
-        type="button"
-        variant="outline-secondary"
-        onClick={() => {
-          setCurlText('');
-          setCurlError(false);
-          setCurlOpen(true);
-        }}
-        title="Build the request from a curl command"
-      >
-        <ClipboardPlus className="me-1" />
-        From curl
-      </Button>
     </>
   );
 
+  const openCurl = () => {
+    setCurlText('');
+    setCurlError(false);
+    setCurlOpen(true);
+  };
+
   return (
     <div className="sb-method-invoker">
-      <Tabs defaultActiveKey="form" id="method-invoker-tabs" className="mb-2" mountOnEnter unmountOnExit>
-        <Tab eventKey="form" title="Form">
-          <FormFromSchema
-            schema={schema}
-            formData={formData}
-            onChange={setFormData}
-            onSubmit={onFormSubmit}
-            actions={actions}
-          />
-        </Tab>
-        <Tab eventKey="raw" title="Raw">
-          <RawJsonEditor
-            schema={schema}
-            method={method}
-            formData={formData}
-            onChange={setFormData}
-            onSubmit={onRawSubmit}
-            actions={actions}
-          />
-        </Tab>
-      </Tabs>
+      <div className="sb-method-invoker__tabs">
+        <Tabs defaultActiveKey="form" id="method-invoker-tabs" className="mb-2" mountOnEnter unmountOnExit>
+          <Tab eventKey="form" title="Form">
+            <FormFromSchema
+              schema={schema}
+              formData={formData}
+              onChange={setFormData}
+              onSubmit={onFormSubmit}
+              actions={actions}
+            />
+          </Tab>
+          <Tab eventKey="raw" title="Raw">
+            <RawJsonEditor
+              schema={schema}
+              method={method}
+              formData={formData}
+              onChange={setFormData}
+              onSubmit={onRawSubmit}
+              actions={actions}
+            />
+          </Tab>
+        </Tabs>
+        <Button
+          size="sm"
+          variant="outline-secondary"
+          className="sb-method-invoker__from-curl"
+          onClick={openCurl}
+          title="Build the request from a curl command"
+        >
+          <ClipboardPlus className="me-1" /> From curl
+        </Button>
+      </div>
 
       {mutation.isPending && (
         <div className="sb-method-invoker__loading" aria-busy="true">

--- a/src/components/MethodInvoker.tsx
+++ b/src/components/MethodInvoker.tsx
@@ -4,7 +4,7 @@ import { BookmarkPlus, Clipboard, ClipboardCheck, ClipboardPlus, Share, XLg } fr
 
 import { useRpc } from '../data/queries';
 import { useClipboard } from '../hooks/useClipboard';
-import { fromCurl, toCurl } from '../lib/curl';
+import { fromCurl, rpcParams, toCurl } from '../lib/curl';
 import { formatBytes, formatDuration, jsonByteSize } from '../lib/format';
 import { createRequest, type JsonRpcParams, type JsonRpcRequest } from '../lib/rpc';
 import type { JsonSchema } from '../lib/smdToJsonSchema';
@@ -112,10 +112,9 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
 
   // Build the form from a pasted curl command (D2).
   const importCurl = () => {
-    const parsed = fromCurl(curlText);
-    const params = parsed?.body && (parsed.body as { params?: JsonRpcParams }).params;
-    if (params && typeof params === 'object' && !Array.isArray(params)) {
-      setFormData(params as Record<string, unknown>);
+    const params = rpcParams(fromCurl(curlText)?.body);
+    if (params) {
+      setFormData(params);
       setCurlOpen(false);
       setCurlText('');
       setCurlError(false);

--- a/src/components/MethodInvoker.tsx
+++ b/src/components/MethodInvoker.tsx
@@ -133,9 +133,9 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
   // Rendered inline to the right of each tab's "Try" button.
   const actions = (
     <>
-      <Button type="button" variant="outline-secondary" onClick={copyCurl}>
+      <Button type="button" variant="outline-secondary" onClick={copyCurl} title="Copy as curl">
         {copied ? <ClipboardCheck className="me-1" /> : <Clipboard className="me-1" />}
-        {copied ? 'Copied' : 'curl'}
+        <span className="sb-action-label">{copied ? 'Copied' : 'curl'}</span>
       </Button>
       <Button
         type="button"
@@ -144,11 +144,11 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
         title="Copy a shareable link with these parameters"
       >
         <Share className="me-1" />
-        {share.copied ? 'Copied' : 'Share'}
+        <span className="sb-action-label">{share.copied ? 'Copied' : 'Share'}</span>
       </Button>
       <Button type="button" variant="outline-secondary" onClick={onSave} title="Save this request">
         <BookmarkPlus className="me-1" />
-        Save
+        <span className="sb-action-label">Save</span>
       </Button>
     </>
   );
@@ -190,7 +190,7 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
           onClick={openCurl}
           title="Build the request from a curl command"
         >
-          <ClipboardPlus className="me-1" /> From curl
+          <ClipboardPlus className="me-1" /> <span className="sb-action-label">From curl</span>
         </Button>
       </div>
 

--- a/src/components/MethodInvoker.tsx
+++ b/src/components/MethodInvoker.tsx
@@ -36,6 +36,9 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
   const { copied, copy } = useClipboard();
   const share = useClipboard();
   const [meta, setMeta] = useState<{ durationMs: number; size: number } | null>(null);
+  // Last shown response, kept across re-runs so the viewer stays mounted and its
+  // expand/collapse state survives (it resets only when the method changes).
+  const [lastResult, setLastResult] = useState<{ value: unknown; errored: boolean } | null>(null);
   const [curlOpen, setCurlOpen] = useState(false);
   const [curlText, setCurlText] = useState('');
   const [curlError, setCurlError] = useState(false);
@@ -60,6 +63,7 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
       {
         onSuccess: (resp) => {
           setMeta({ durationMs: performance.now() - startedAtRef.current, size: jsonByteSize(resp) });
+          setLastResult({ value: resp.error ?? resp.result, errored: Boolean(resp.error) });
           addHistory({
             id: crypto.randomUUID(),
             method,
@@ -123,12 +127,9 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
     }
   };
 
-  const result = mutation.data;
   const cancelled = isAbort(mutation.error);
-  // Unify success and JSON-RPC error into one result block (header + timing).
-  const errored = Boolean(result?.error);
-  const payload = errored ? result?.error : result?.result;
-  const showResult = !mutation.isPending && !cancelled && payload !== undefined;
+  // Show the last response (kept mounted across re-runs to preserve tree state).
+  const showResult = lastResult !== null && lastResult.value !== undefined;
 
   // Rendered inline to the right of each tab's "Try" button.
   const actions = (
@@ -216,15 +217,15 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
         </Alert>
       )}
 
-      {showResult && (
+      {showResult && lastResult && (
         <div className="sb-method-invoker__result">
           <JsonViewer
-            json={payload}
+            json={lastResult.value}
             title="Response"
-            error={errored}
+            error={lastResult.errored}
             onSave={() => {
               const name = window.prompt('Save response as:', method);
-              if (name) saveResponse(name, method, payload);
+              if (name) saveResponse(name, method, lastResult.value);
             }}
           />
           {meta && (

--- a/src/components/MethodInvoker.tsx
+++ b/src/components/MethodInvoker.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { Alert, Button, Spinner, Tab, Tabs } from 'react-bootstrap';
-import { BookmarkPlus, Clipboard, ClipboardCheck, Share, XLg } from 'react-bootstrap-icons';
+import { Alert, Button, Form, Modal, Spinner, Tab, Tabs } from 'react-bootstrap';
+import { BookmarkPlus, Clipboard, ClipboardCheck, ClipboardPlus, Share, XLg } from 'react-bootstrap-icons';
 
 import { useRpc } from '../data/queries';
 import { useClipboard } from '../hooks/useClipboard';
-import { toCurl } from '../lib/curl';
+import { fromCurl, toCurl } from '../lib/curl';
 import { formatBytes, formatDuration, jsonByteSize } from '../lib/format';
 import { createRequest, type JsonRpcParams, type JsonRpcRequest } from '../lib/rpc';
 import type { JsonSchema } from '../lib/smdToJsonSchema';
@@ -35,6 +35,9 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
   const { copied, copy } = useClipboard();
   const share = useClipboard();
   const [meta, setMeta] = useState<{ durationMs: number; size: number } | null>(null);
+  const [curlOpen, setCurlOpen] = useState(false);
+  const [curlText, setCurlText] = useState('');
+  const [curlError, setCurlError] = useState(false);
   const controllerRef = useRef<AbortController | null>(null);
   const startedAtRef = useRef(0);
 
@@ -106,6 +109,20 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
     if (name) saveRequest(name, method, formData);
   };
 
+  // Build the form from a pasted curl command (D2).
+  const importCurl = () => {
+    const parsed = fromCurl(curlText);
+    const params = parsed?.body && (parsed.body as { params?: JsonRpcParams }).params;
+    if (params && typeof params === 'object' && !Array.isArray(params)) {
+      setFormData(params as Record<string, unknown>);
+      setCurlOpen(false);
+      setCurlText('');
+      setCurlError(false);
+    } else {
+      setCurlError(true);
+    }
+  };
+
   const result = mutation.data;
   const cancelled = isAbort(mutation.error);
   // Unify success and JSON-RPC error into one result block (header + timing).
@@ -132,6 +149,19 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
       <Button type="button" variant="outline-secondary" onClick={onSave} title="Save this request">
         <BookmarkPlus className="me-1" />
         Save
+      </Button>
+      <Button
+        type="button"
+        variant="outline-secondary"
+        onClick={() => {
+          setCurlText('');
+          setCurlError(false);
+          setCurlOpen(true);
+        }}
+        title="Build the request from a curl command"
+      >
+        <ClipboardPlus className="me-1" />
+        From curl
       </Button>
     </>
   );
@@ -192,6 +222,36 @@ export function MethodInvoker({ schema, method, endpoint, headers }: MethodInvok
           )}
         </div>
       )}
+
+      <Modal show={curlOpen} onHide={() => setCurlOpen(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title className="h6">Import from curl</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Control
+            as="textarea"
+            rows={6}
+            value={curlText}
+            onChange={(e) => setCurlText(e.target.value)}
+            placeholder="Paste a curl command…"
+            aria-label="curl command"
+            autoFocus
+          />
+          {curlError && (
+            <Alert variant="danger" className="mt-2 py-1">
+              Could not read JSON-RPC params from this curl command.
+            </Alert>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setCurlOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="success" onClick={importCurl} disabled={!curlText.trim()}>
+            Import
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </div>
   );
 }

--- a/src/components/MethodViewer.tsx
+++ b/src/components/MethodViewer.tsx
@@ -30,7 +30,7 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
     <div className="sb-method-viewer">
       <Row>
         {showInfo && (
-          <Col md={showTry ? 7 : 12}>
+          <Col xs={12} lg={showTry ? 7 : 12}>
             <h3 className="sb-method-viewer__title">
               {selected}
               {showTry ? (
@@ -60,7 +60,7 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
         )}
 
         {showTry && (
-          <Col md={showInfo ? 5 : 12}>
+          <Col xs={12} lg={showInfo ? 5 : 12}>
             <h3 className="sb-method-viewer__title">
               Try it out
               {showInfo ? (

--- a/src/components/MethodViewer.tsx
+++ b/src/components/MethodViewer.tsx
@@ -34,12 +34,24 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
             <h3 className="sb-method-viewer__title">
               {selected}
               {showTry ? (
-                <Button size="sm" variant="outline-secondary" onClick={() => setShowInfo(false)}>
-                  <EyeSlash className="me-1" /> Hide
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={() => setShowInfo(false)}
+                  title="Hide description"
+                  aria-label="Hide description"
+                >
+                  <EyeSlash />
                 </Button>
               ) : (
-                <Button size="sm" variant="outline-secondary" onClick={() => setShowTry(true)}>
-                  <Eye className="me-1" /> Try it
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={() => setShowTry(true)}
+                  title="Show Try it out"
+                  aria-label="Show Try it out"
+                >
+                  <Eye />
                 </Button>
               )}
             </h3>
@@ -52,12 +64,24 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
             <h3 className="sb-method-viewer__title">
               Try it out
               {showInfo ? (
-                <Button size="sm" variant="outline-secondary" onClick={() => setShowTry(false)}>
-                  <EyeSlash className="me-1" /> Hide
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={() => setShowTry(false)}
+                  title="Hide Try it out"
+                  aria-label="Hide Try it out"
+                >
+                  <EyeSlash />
                 </Button>
               ) : (
-                <Button size="sm" variant="outline-secondary" onClick={() => setShowInfo(true)}>
-                  <Eye className="me-1" /> Show description
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={() => setShowInfo(true)}
+                  title="Show description"
+                  aria-label="Show description"
+                >
+                  <Eye />
                 </Button>
               )}
             </h3>

--- a/src/components/ParamsTable.tsx
+++ b/src/components/ParamsTable.tsx
@@ -86,7 +86,7 @@ export function ParamsTable({
   definitions?: Record<string, SmdDefinition>;
 }) {
   return (
-    <Table striped bordered hover size="sm" className="sb-params">
+    <Table striped bordered hover size="sm" responsive className="sb-params">
       <thead>
         <tr>
           <th>Parameter</th>

--- a/src/components/ParamsTable.tsx
+++ b/src/components/ParamsTable.tsx
@@ -37,6 +37,9 @@ function Rows({ properties, definitions, depth, seen }: RowsProps) {
       {Object.entries(properties).map(([name, node]) => {
         const { rows, seen: childSeen } = childrenOf(node, definitions, seen);
         const enums = node.enum?.filter((v) => v !== undefined && v !== null) ?? [];
+        const typeLabel = resolveType(node);
+        // Drop descriptions that merely echo the type name (zenrpc default).
+        const desc = node.description && node.description !== typeLabel ? node.description : '';
         return (
           <Fragment key={`${depth}:${name}`}>
             <tr>
@@ -44,11 +47,11 @@ function Rows({ properties, definitions, depth, seen }: RowsProps) {
                 <span className="sb-params__req">{node.optional ? null : <RequiredMark />}</span>
                 <CodeChip>{name}</CodeChip>
                 <span className="sb-params__type">
-                  <CodeChip variant="type">{resolveType(node)}</CodeChip>
+                  <CodeChip variant="type">{typeLabel}</CodeChip>
                 </span>
               </td>
               <td>
-                {node.description ? node.description : <span className="sb-muted">—</span>}
+                {desc ? desc : <span className="sb-muted">—</span>}
                 {enums.length > 0 && (
                   <div className="sb-params__enum">
                     {enums.map((v, i) => (

--- a/src/components/ParamsTable.tsx
+++ b/src/components/ParamsTable.tsx
@@ -1,5 +1,6 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { Table } from 'react-bootstrap';
+import { ChevronDown, ChevronRight } from 'react-bootstrap-icons';
 
 import { CodeChip } from '../design/components/CodeChip';
 import { RequiredMark } from '../design/components/RequiredMark';
@@ -10,8 +11,12 @@ interface RowsProps {
   properties: Record<string, DescNode>;
   definitions: Record<string, SmdDefinition>;
   depth: number;
+  /** Dotted path of the parent row (for collapse keys); '' at the top level. */
+  parentPath: string;
   /** Definition names already expanded on this path (cycle guard). */
   seen: ReadonlySet<string>;
+  collapsed: ReadonlySet<string>;
+  onToggle: (path: string) => void;
 }
 
 /** Resolves the child rows for a node: inline properties or a referenced definition. */
@@ -31,19 +36,34 @@ function childrenOf(
   return { seen };
 }
 
-function Rows({ properties, definitions, depth, seen }: RowsProps) {
+function Rows({ properties, definitions, depth, parentPath, seen, collapsed, onToggle }: RowsProps) {
   return (
     <>
       {Object.entries(properties).map(([name, node]) => {
+        const path = parentPath ? `${parentPath}.${name}` : name;
         const { rows, seen: childSeen } = childrenOf(node, definitions, seen);
+        const isCollapsed = collapsed.has(path);
         const enums = node.enum?.filter((v) => v !== undefined && v !== null) ?? [];
         const typeLabel = resolveType(node);
         // Drop descriptions that merely echo the type name (zenrpc default).
         const desc = node.description && node.description !== typeLabel ? node.description : '';
         return (
-          <Fragment key={`${depth}:${name}`}>
+          <Fragment key={path}>
             <tr>
               <td style={{ paddingLeft: depth * 18 + 8 }}>
+                {rows ? (
+                  <button
+                    type="button"
+                    className="sb-params__caret"
+                    aria-expanded={!isCollapsed}
+                    aria-label={isCollapsed ? `Expand ${name}` : `Collapse ${name}`}
+                    onClick={() => onToggle(path)}
+                  >
+                    {isCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
+                  </button>
+                ) : (
+                  <span className="sb-params__caret" aria-hidden="true" />
+                )}
                 <span className="sb-params__req">{node.optional ? null : <RequiredMark />}</span>
                 <CodeChip>{name}</CodeChip>
                 <span className="sb-params__type">
@@ -63,8 +83,16 @@ function Rows({ properties, definitions, depth, seen }: RowsProps) {
                 )}
               </td>
             </tr>
-            {rows && (
-              <Rows properties={rows} definitions={definitions} depth={depth + 1} seen={childSeen} />
+            {rows && !isCollapsed && (
+              <Rows
+                properties={rows}
+                definitions={definitions}
+                depth={depth + 1}
+                parentPath={path}
+                seen={childSeen}
+                collapsed={collapsed}
+                onToggle={onToggle}
+              />
             )}
           </Fragment>
         );
@@ -75,8 +103,9 @@ function Rows({ properties, definitions, depth, seen }: RowsProps) {
 
 /**
  * Single flat table of parameters/properties. Nested object types (inline
- * properties or `$ref` definitions) are expanded inline as indented rows, so
- * there are no separate "Definition of X" tables.
+ * properties or `$ref` definitions) are expanded inline as indented rows, with
+ * a chevron to collapse/expand each branch; there are no separate
+ * "Definition of X" tables.
  */
 export function ParamsTable({
   properties,
@@ -85,6 +114,15 @@ export function ParamsTable({
   properties: Record<string, DescNode>;
   definitions?: Record<string, SmdDefinition>;
 }) {
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
+  const onToggle = (path: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+
   return (
     <Table striped bordered hover size="sm" responsive className="sb-params">
       <thead>
@@ -94,7 +132,15 @@ export function ParamsTable({
         </tr>
       </thead>
       <tbody>
-        <Rows properties={properties} definitions={definitions} depth={0} seen={new Set()} />
+        <Rows
+          properties={properties}
+          definitions={definitions}
+          depth={0}
+          parentPath=""
+          seen={new Set()}
+          collapsed={collapsed}
+          onToggle={onToggle}
+        />
       </tbody>
     </Table>
   );

--- a/src/components/ParamsTable.tsx
+++ b/src/components/ParamsTable.tsx
@@ -3,28 +3,66 @@ import { Table } from 'react-bootstrap';
 
 import { CodeChip } from '../design/components/CodeChip';
 import { RequiredMark } from '../design/components/RequiredMark';
-import { resolveType, type DescNode } from './paramTypes';
+import type { SmdDefinition } from '../types/smd';
+import { referencedTypeName, resolveType, type DescNode } from './paramTypes';
 
-function Rows({ properties, namespace }: { properties: Record<string, DescNode>; namespace?: string }) {
+interface RowsProps {
+  properties: Record<string, DescNode>;
+  definitions: Record<string, SmdDefinition>;
+  depth: number;
+  /** Definition names already expanded on this path (cycle guard). */
+  seen: ReadonlySet<string>;
+}
+
+/** Resolves the child rows for a node: inline properties or a referenced definition. */
+function childrenOf(
+  node: DescNode,
+  definitions: Record<string, SmdDefinition>,
+  seen: ReadonlySet<string>,
+): { rows?: Record<string, DescNode>; seen: ReadonlySet<string> } {
+  if (node.properties && Object.keys(node.properties).length) {
+    return { rows: node.properties, seen };
+  }
+  const ref = referencedTypeName(node);
+  const def = ref && !seen.has(ref) ? definitions[ref] : undefined;
+  if (def?.properties && Object.keys(def.properties).length) {
+    return { rows: def.properties as Record<string, DescNode>, seen: new Set(seen).add(ref) };
+  }
+  return { seen };
+}
+
+function Rows({ properties, definitions, depth, seen }: RowsProps) {
   return (
     <>
       {Object.entries(properties).map(([name, node]) => {
-        const path = namespace ? `${namespace}.${name}` : name;
+        const { rows, seen: childSeen } = childrenOf(node, definitions, seen);
+        const enums = node.enum?.filter((v) => v !== undefined && v !== null) ?? [];
         return (
-          <Fragment key={path}>
+          <Fragment key={`${depth}:${name}`}>
             <tr>
-              <td>
-                <CodeChip>{path}</CodeChip>
+              <td style={{ paddingLeft: depth * 18 + 8 }}>
+                <span className="sb-params__req">{node.optional ? null : <RequiredMark />}</span>
+                <CodeChip>{name}</CodeChip>
+                <span className="sb-params__type">
+                  <CodeChip variant="type">{resolveType(node)}</CodeChip>
+                </span>
               </td>
               <td>
                 {node.description ? node.description : <span className="sb-muted">—</span>}
+                {enums.length > 0 && (
+                  <div className="sb-params__enum">
+                    {enums.map((v, i) => (
+                      <CodeChip key={i} variant="type">
+                        {String(v)}
+                      </CodeChip>
+                    ))}
+                  </div>
+                )}
               </td>
-              <td>
-                <CodeChip variant="type">{resolveType(node)}</CodeChip>
-              </td>
-              <td>{node.optional ? '' : <RequiredMark />}</td>
             </tr>
-            {node.properties && <Rows properties={node.properties} namespace={path} />}
+            {rows && (
+              <Rows properties={rows} definitions={definitions} depth={depth + 1} seen={childSeen} />
+            )}
           </Fragment>
         );
       })}
@@ -32,20 +70,28 @@ function Rows({ properties, namespace }: { properties: Record<string, DescNode>;
   );
 }
 
-/** Recursive table of parameter/property descriptions. */
-export function ParamsTable({ properties }: { properties: Record<string, DescNode> }) {
+/**
+ * Single flat table of parameters/properties. Nested object types (inline
+ * properties or `$ref` definitions) are expanded inline as indented rows, so
+ * there are no separate "Definition of X" tables.
+ */
+export function ParamsTable({
+  properties,
+  definitions = {},
+}: {
+  properties: Record<string, DescNode>;
+  definitions?: Record<string, SmdDefinition>;
+}) {
   return (
-    <Table striped bordered hover size="sm">
+    <Table striped bordered hover size="sm" className="sb-params">
       <thead>
         <tr>
           <th>Parameter</th>
           <th>Description</th>
-          <th>Type</th>
-          <th>Required</th>
         </tr>
       </thead>
       <tbody>
-        <Rows properties={properties} />
+        <Rows properties={properties} definitions={definitions} depth={0} seen={new Set()} />
       </tbody>
     </Table>
   );

--- a/src/components/ParamsTable.tsx
+++ b/src/components/ParamsTable.tsx
@@ -1,10 +1,11 @@
-import { Fragment, useState } from 'react';
+import { Fragment } from 'react';
 import { Table } from 'react-bootstrap';
-import { ChevronDown, ChevronRight } from 'react-bootstrap-icons';
 
 import { CodeChip } from '../design/components/CodeChip';
 import { RequiredMark } from '../design/components/RequiredMark';
+import { useSetToggle } from '../hooks/useSetToggle';
 import type { SmdDefinition } from '../types/smd';
+import { CollapseCaret } from './CollapseCaret';
 import { referencedTypeName, resolveType, type DescNode } from './paramTypes';
 
 interface RowsProps {
@@ -52,15 +53,7 @@ function Rows({ properties, definitions, depth, parentPath, seen, collapsed, onT
             <tr>
               <td style={{ paddingLeft: depth * 18 + 8 }}>
                 {rows ? (
-                  <button
-                    type="button"
-                    className="sb-params__caret"
-                    aria-expanded={!isCollapsed}
-                    aria-label={isCollapsed ? `Expand ${name}` : `Collapse ${name}`}
-                    onClick={() => onToggle(path)}
-                  >
-                    {isCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
-                  </button>
+                  <CollapseCaret open={!isCollapsed} onToggle={() => onToggle(path)} name={name} />
                 ) : (
                   <span className="sb-params__caret" aria-hidden="true" />
                 )}
@@ -114,14 +107,7 @@ export function ParamsTable({
   properties: Record<string, DescNode>;
   definitions?: Record<string, SmdDefinition>;
 }) {
-  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
-  const onToggle = (path: string) =>
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
-    });
+  const [collapsed, onToggle] = useSetToggle();
 
   return (
     <Table striped bordered hover size="sm" responsive className="sb-params">

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -4,7 +4,7 @@ import { ArrowClockwise, Download, PlusLg, Trash } from 'react-bootstrap-icons';
 
 import { refreshSmd, useSmd } from '../data/queries';
 import { defaultSmdUrlFromLocation, deriveEndpoint } from '../lib/smd';
-import { useStore, type Preset } from '../store/store';
+import { selectNavbarColor, useStore, type ConfigBundle, type Preset } from '../store/store';
 
 interface HeaderRow {
   key: string;
@@ -68,7 +68,7 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
 
   // Navbar color binds to the active env (if any), else the global pref.
   const activeEnv = environments.find((e) => e.id === activeEnvironmentId);
-  const currentColor = activeEnv?.color || navbarColor;
+  const currentColor = useStore(selectNavbarColor);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedUrl(smdUrl), DEBOUNCE_MS);
@@ -139,22 +139,19 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const submitDisabled = mode === 'init' && (!smdUrl.trim() || pendingSubmit);
 
   const exportConfig = () => {
-    const data = JSON.stringify(
-      {
-        endpoint: effectiveEndpoint,
-        smdUrl: project.smdUrl,
-        headers: headersObj,
-        favorites,
-        saved,
-        savedResponses,
-        environments,
-        idLinks,
-        navbarColor,
-        theme,
-      },
-      null,
-      2,
-    );
+    const bundle: ConfigBundle = {
+      endpoint: effectiveEndpoint,
+      smdUrl: project.smdUrl,
+      headers: headersObj,
+      favorites,
+      saved,
+      savedResponses,
+      environments,
+      idLinks,
+      navbarColor,
+      theme,
+    };
+    const data = JSON.stringify(bundle, null, 2);
     const url = URL.createObjectURL(new Blob([data], { type: 'application/json' }));
     const a = document.createElement('a');
     a.href = url;

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -4,7 +4,7 @@ import { ArrowClockwise, Download, PlusLg, Trash } from 'react-bootstrap-icons';
 
 import { refreshSmd, useSmd } from '../data/queries';
 import { defaultSmdUrlFromLocation, deriveEndpoint } from '../lib/smd';
-import { useStore } from '../store/store';
+import { useStore, type Preset } from '../store/store';
 
 interface HeaderRow {
   key: string;
@@ -41,6 +41,7 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const updateSettings = useStore((s) => s.updateSettings);
   const favorites = useStore((s) => s.prefs.favorites);
   const saved = useStore((s) => s.saved);
+  const savedResponses = useStore((s) => s.savedResponses);
   const environments = useStore((s) => s.environments);
   const navbarColor = useStore((s) => s.prefs.navbarColor);
   const setNavbarColor = useStore((s) => s.setNavbarColor);
@@ -48,6 +49,7 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const idLinks = useStore((s) => s.idLinks);
   const setIdLink = useStore((s) => s.setIdLink);
   const removeIdLink = useStore((s) => s.removeIdLink);
+  const presets = useStore((s) => s.presets);
 
   const [smdUrl, setSmdUrl] = useState(
     () => project.smdUrl || defaultSmdUrlFromLocation(window.location.href),
@@ -86,6 +88,14 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const removeHeader = (i: number) => setHeaders((h) => h.filter((_, idx) => idx !== i));
   const patchHeader = (i: number, patch: Partial<HeaderRow>) =>
     setHeaders((h) => h.map((row, idx) => (idx === i ? { ...row, ...patch } : row)));
+
+  // Fill the form from a host-provided preset (A2); the user reviews, then Creates.
+  const applyPreset = (p: Preset) => {
+    setSmdUrl(p.smdUrl);
+    setDebouncedUrl(p.smdUrl);
+    setEndpoint(p.endpoint ?? '');
+    setHeaders(p.headers ? Object.entries(p.headers).map(([key, value]) => ({ key, value })) : []);
+  };
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -131,6 +141,7 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
         headers: headersObj,
         favorites,
         saved,
+        savedResponses,
         environments,
         idLinks,
         navbarColor,
@@ -230,6 +241,25 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
             >
               <PlusLg />
             </Button>
+          </div>
+        </div>
+      )}
+
+      {mode !== 'settings' && presets.length > 0 && (
+        <div className="mb-3">
+          <h5>Presets</h5>
+          <div className="sb-project__swatches">
+            {presets.map((p) => (
+              <Button
+                key={p.name}
+                type="button"
+                size="sm"
+                variant="outline-secondary"
+                onClick={() => applyPreset(p)}
+              >
+                {p.name}
+              </Button>
+            ))}
           </div>
         </div>
       )}

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Form, Spinner } from 'react-bootstrap';
-import { ArrowClockwise, Download, PlusLg, Trash, Upload } from 'react-bootstrap-icons';
+import { ArrowClockwise, Download, PlusLg, Trash } from 'react-bootstrap-icons';
 
 import { refreshSmd, useSmd } from '../data/queries';
 import { defaultSmdUrlFromLocation, deriveEndpoint } from '../lib/smd';
-import { useStore, type Environment, type SavedRequest } from '../store/store';
+import { useStore } from '../store/store';
 
 interface HeaderRow {
   key: string;
@@ -31,7 +31,6 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const project = useStore((s) => s.project);
   const createProject = useStore((s) => s.createProject);
   const updateSettings = useStore((s) => s.updateSettings);
-  const importConfig = useStore((s) => s.importConfig);
   const favorites = useStore((s) => s.prefs.favorites);
   const saved = useStore((s) => s.saved);
   const environments = useStore((s) => s.environments);
@@ -44,7 +43,9 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
     Object.entries(project.headers).map(([key, value]) => ({ key, value })),
   );
   const [debouncedUrl, setDebouncedUrl] = useState(smdUrl);
-  const fileRef = useRef<HTMLInputElement>(null);
+  // Set when the user submits before the schema has finished loading: we kick
+  // off the fetch immediately and enter as soon as it validates (A1).
+  const [pendingSubmit, setPendingSubmit] = useState(false);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedUrl(smdUrl), DEBOUNCE_MS);
@@ -74,13 +75,37 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
     e.preventDefault();
     if (mode === 'settings') {
       updateSettings({ endpoint: effectiveEndpoint, headers: headersObj });
-    } else {
-      createProject({ endpoint: effectiveEndpoint, smdUrl: debouncedUrl, headers: headersObj });
+      onClose?.();
+      return;
     }
-    onClose?.();
+    // Init: enter immediately if the schema is already loaded.
+    if (smd.data) {
+      createProject({ endpoint: effectiveEndpoint, smdUrl: debouncedUrl, headers: headersObj });
+      onClose?.();
+      return;
+    }
+    // Schema not loaded yet: flush the debounce so the fetch starts now, and
+    // let the effect below enter as soon as it succeeds (single click).
+    if (smdUrl.trim()) {
+      setDebouncedUrl(smdUrl);
+      setPendingSubmit(true);
+    }
   };
 
-  const submitDisabled = mode === 'init' && !smd.data;
+  // Complete a pending submit once the schema resolves (success → enter,
+  // error → drop back to the form with its inline feedback).
+  useEffect(() => {
+    if (!pendingSubmit) return;
+    if (smd.data) {
+      createProject({ endpoint: effectiveEndpoint, smdUrl: debouncedUrl, headers: headersObj });
+      setPendingSubmit(false);
+      onClose?.();
+    } else if (smd.isError) {
+      setPendingSubmit(false);
+    }
+  }, [pendingSubmit, smd.data, smd.isError, effectiveEndpoint, debouncedUrl, headersObj, createProject, onClose]);
+
+  const submitDisabled = mode === 'init' && (!smdUrl.trim() || pendingSubmit);
 
   const exportConfig = () => {
     const data = JSON.stringify(
@@ -96,24 +121,6 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
     URL.revokeObjectURL(url);
   };
 
-  const loadConfigFile = async (file: File) => {
-    try {
-      const cfg = JSON.parse(await file.text()) as Partial<{
-        endpoint: string;
-        smdUrl: string;
-        headers: Record<string, string>;
-        favorites: string[];
-        saved: SavedRequest[];
-        environments: Environment[];
-      }>;
-      if (!cfg.smdUrl) return;
-      importConfig(cfg);
-      onClose?.();
-    } catch {
-      // ignore invalid config file
-    }
-  };
-
   return (
     <Form className="sb-project" onSubmit={onSubmit}>
       {mode === 'settings' && (
@@ -123,24 +130,6 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
             <Button type="button" size="sm" variant="outline-secondary" onClick={exportConfig}>
               <Download className="me-1" /> Export config
             </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline-secondary"
-              onClick={() => fileRef.current?.click()}
-            >
-              <Upload className="me-1" /> Import config
-            </Button>
-            <input
-              ref={fileRef}
-              type="file"
-              accept="application/json"
-              hidden
-              onChange={(e) => {
-                const f = e.target.files?.[0];
-                if (f) void loadConfigFile(f);
-              }}
-            />
           </div>
         </div>
       )}
@@ -208,7 +197,15 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
 
       <div className="sb-project__actions">
         <Button type="submit" variant={mode === 'settings' ? 'primary' : 'success'} disabled={submitDisabled}>
-          {mode === 'settings' ? 'Update' : 'Create'}
+          {mode === 'settings' ? (
+            'Update'
+          ) : pendingSubmit ? (
+            <>
+              <Spinner animation="border" size="sm" className="me-1" /> Checking…
+            </>
+          ) : (
+            'Create'
+          )}
         </Button>
         {mode === 'settings' && (
           <Button

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -26,6 +26,14 @@ interface ProjectProps {
 
 const DEBOUNCE_MS = 800;
 
+// Navbar presets to tell environments apart at a glance ('' = default ocean).
+const NAVBAR_PRESETS: { label: string; color: string }[] = [
+  { label: 'Default', color: '' },
+  { label: 'Dev', color: '#047857' },
+  { label: 'Stage', color: '#b45309' },
+  { label: 'Prod', color: '#be123c' },
+];
+
 /** Project setup (initial) and settings form. */
 export function Project({ mode = 'init', onClose }: ProjectProps) {
   const project = useStore((s) => s.project);
@@ -34,6 +42,8 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const favorites = useStore((s) => s.prefs.favorites);
   const saved = useStore((s) => s.saved);
   const environments = useStore((s) => s.environments);
+  const navbarColor = useStore((s) => s.prefs.navbarColor);
+  const setNavbarColor = useStore((s) => s.setNavbarColor);
 
   const [smdUrl, setSmdUrl] = useState(
     () => project.smdUrl || defaultSmdUrlFromLocation(window.location.href),
@@ -130,6 +140,32 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
             <Button type="button" size="sm" variant="outline-secondary" onClick={exportConfig}>
               <Download className="me-1" /> Export config
             </Button>
+          </div>
+
+          <h5 className="mt-3">Navbar color</h5>
+          <div className="sb-project__swatches">
+            {NAVBAR_PRESETS.map((p) => (
+              <Button
+                key={p.label}
+                type="button"
+                size="sm"
+                variant={navbarColor === p.color ? 'primary' : 'outline-secondary'}
+                onClick={() => setNavbarColor(p.color)}
+              >
+                {p.color && (
+                  <span className="sb-project__dot" style={{ background: p.color }} aria-hidden="true" />
+                )}
+                {p.label}
+              </Button>
+            ))}
+            <Form.Control
+              type="color"
+              value={navbarColor || '#075985'}
+              onChange={(e) => setNavbarColor(e.target.value)}
+              title="Custom navbar color"
+              aria-label="Custom navbar color"
+              className="sb-project__color"
+            />
           </div>
         </div>
       )}

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -44,6 +44,9 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const environments = useStore((s) => s.environments);
   const navbarColor = useStore((s) => s.prefs.navbarColor);
   const setNavbarColor = useStore((s) => s.setNavbarColor);
+  const idLinks = useStore((s) => s.idLinks);
+  const setIdLink = useStore((s) => s.setIdLink);
+  const removeIdLink = useStore((s) => s.removeIdLink);
 
   const [smdUrl, setSmdUrl] = useState(
     () => project.smdUrl || defaultSmdUrlFromLocation(window.location.href),
@@ -56,6 +59,8 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   // Set when the user submits before the schema has finished loading: we kick
   // off the fetch immediately and enter as soon as it validates (A1).
   const [pendingSubmit, setPendingSubmit] = useState(false);
+  const [linkField, setLinkField] = useState('');
+  const [linkUrl, setLinkUrl] = useState('');
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedUrl(smdUrl), DEBOUNCE_MS);
@@ -166,6 +171,54 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
               aria-label="Custom navbar color"
               className="sb-project__color"
             />
+          </div>
+
+          <h5 className="mt-3">Linked fields</h5>
+          <p className="sb-muted sb-project__hint-text">
+            Turn id values in responses into links. Use <code>{'{id}'}</code> as the placeholder.
+          </p>
+          {Object.entries(idLinks).map(([field, url]) => (
+            <div className="sb-project__link-row" key={field}>
+              <code className="sb-param-name">{field}</code>
+              <span className="sb-muted text-truncate" title={url}>
+                {url}
+              </span>
+              <Button
+                variant="outline-danger"
+                size="sm"
+                onClick={() => removeIdLink(field)}
+                aria-label={`Remove ${field}`}
+                title="Remove rule"
+              >
+                <Trash />
+              </Button>
+            </div>
+          ))}
+          <div className="sb-project__header-row">
+            <Form.Control
+              placeholder="field (e.g. productId)"
+              value={linkField}
+              onChange={(e) => setLinkField(e.target.value)}
+            />
+            <Form.Control
+              placeholder="https://…/{id}"
+              value={linkUrl}
+              onChange={(e) => setLinkUrl(e.target.value)}
+            />
+            <Button
+              size="sm"
+              variant="outline-secondary"
+              disabled={!linkField.trim() || !linkUrl.trim()}
+              onClick={() => {
+                setIdLink(linkField.trim(), linkUrl.trim());
+                setLinkField('');
+                setLinkUrl('');
+              }}
+              aria-label="Add link rule"
+              title="Add rule"
+            >
+              <PlusLg />
+            </Button>
           </div>
         </div>
       )}

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -44,6 +44,7 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const environments = useStore((s) => s.environments);
   const navbarColor = useStore((s) => s.prefs.navbarColor);
   const setNavbarColor = useStore((s) => s.setNavbarColor);
+  const theme = useStore((s) => s.prefs.theme);
   const idLinks = useStore((s) => s.idLinks);
   const setIdLink = useStore((s) => s.setIdLink);
   const removeIdLink = useStore((s) => s.removeIdLink);
@@ -124,7 +125,17 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
 
   const exportConfig = () => {
     const data = JSON.stringify(
-      { endpoint: effectiveEndpoint, smdUrl: project.smdUrl, headers: headersObj, favorites, saved, environments },
+      {
+        endpoint: effectiveEndpoint,
+        smdUrl: project.smdUrl,
+        headers: headersObj,
+        favorites,
+        saved,
+        environments,
+        idLinks,
+        navbarColor,
+        theme,
+      },
       null,
       2,
     );

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -45,6 +45,7 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const environments = useStore((s) => s.environments);
   const navbarColor = useStore((s) => s.prefs.navbarColor);
   const setNavbarColor = useStore((s) => s.setNavbarColor);
+  const activeEnvironmentId = useStore((s) => s.activeEnvironmentId);
   const theme = useStore((s) => s.prefs.theme);
   const idLinks = useStore((s) => s.idLinks);
   const setIdLink = useStore((s) => s.setIdLink);
@@ -64,6 +65,10 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
   const [pendingSubmit, setPendingSubmit] = useState(false);
   const [linkField, setLinkField] = useState('');
   const [linkUrl, setLinkUrl] = useState('');
+
+  // Navbar color binds to the active env (if any), else the global pref.
+  const activeEnv = environments.find((e) => e.id === activeEnvironmentId);
+  const currentColor = activeEnv?.color || navbarColor;
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedUrl(smdUrl), DEBOUNCE_MS);
@@ -169,14 +174,14 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
             </Button>
           </div>
 
-          <h5 className="mt-3">Navbar color</h5>
+          <h5 className="mt-3">Navbar color{activeEnv ? ` · ${activeEnv.name}` : ''}</h5>
           <div className="sb-project__swatches">
             {NAVBAR_PRESETS.map((p) => (
               <Button
                 key={p.label}
                 type="button"
                 size="sm"
-                variant={navbarColor === p.color ? 'primary' : 'outline-secondary'}
+                variant={currentColor === p.color ? 'primary' : 'outline-secondary'}
                 onClick={() => setNavbarColor(p.color)}
               >
                 {p.color && (
@@ -187,7 +192,7 @@ export function Project({ mode = 'init', onClose }: ProjectProps) {
             ))}
             <Form.Control
               type="color"
-              value={navbarColor || '#075985'}
+              value={currentColor || '#075985'}
               onChange={(e) => setNavbarColor(e.target.value)}
               title="Custom navbar color"
               aria-label="Custom navbar color"

--- a/src/components/RawJsonEditor.tsx
+++ b/src/components/RawJsonEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 
-import { fromCurl } from '../lib/curl';
+import { fromCurl, rpcParams } from '../lib/curl';
 import { getParamsTemplate, type JsonSchema } from '../lib/smdToJsonSchema';
 import type { JsonRpcParams } from '../lib/rpc';
 import { CodeEditor } from './CodeEditor';
@@ -59,13 +59,10 @@ export function RawJsonEditor({ schema, method, formData, onChange, onSubmit, ac
     if (/^\s*curl\b/.test(next)) {
       const parsed = fromCurl(next);
       if (parsed?.body !== undefined) {
-        const pretty = JSON.stringify(parsed.body, null, 2);
-        setValue(pretty);
+        setValue(JSON.stringify(parsed.body, null, 2));
         setValid(true);
-        const params = (parsed.body as { params?: JsonRpcParams }).params;
-        if (params && typeof params === 'object' && !Array.isArray(params)) {
-          onChange(params as Record<string, unknown>);
-        }
+        const params = rpcParams(parsed.body);
+        if (params) onChange(params);
         return;
       }
     }

--- a/src/components/RawJsonEditor.tsx
+++ b/src/components/RawJsonEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 
+import { fromCurl } from '../lib/curl';
 import { getParamsTemplate, type JsonSchema } from '../lib/smdToJsonSchema';
 import type { JsonRpcParams } from '../lib/rpc';
 import { CodeEditor } from './CodeEditor';
@@ -54,6 +55,20 @@ export function RawJsonEditor({ schema, method, formData, onChange, onSubmit, ac
   };
 
   const handleChange = (next: string) => {
+    // Pasting a curl command auto-expands into its JSON-RPC request (D2).
+    if (/^\s*curl\b/.test(next)) {
+      const parsed = fromCurl(next);
+      if (parsed?.body !== undefined) {
+        const pretty = JSON.stringify(parsed.body, null, 2);
+        setValue(pretty);
+        setValid(true);
+        const params = (parsed.body as { params?: JsonRpcParams }).params;
+        if (params && typeof params === 'object' && !Array.isArray(params)) {
+          onChange(params as Record<string, unknown>);
+        }
+        return;
+      }
+    }
     setValue(next);
     tryParse(next);
   };

--- a/src/components/Saved.tsx
+++ b/src/components/Saved.tsx
@@ -1,21 +1,10 @@
-import { useState } from 'react';
 import { Badge, Button, Tab, Tabs } from 'react-bootstrap';
-import { ArrowDown, ArrowUp, ChevronDown, ChevronRight, Pencil, Trash } from 'react-bootstrap-icons';
+import { ArrowDown, ArrowUp, Pencil, Trash } from 'react-bootstrap-icons';
 
+import { useSetToggle } from '../hooks/useSetToggle';
 import { useStore } from '../store/store';
+import { CollapseCaret } from './CollapseCaret';
 import { JsonViewer } from './JsonViewer';
-
-function useToggle() {
-  const [open, setOpen] = useState<ReadonlySet<string>>(new Set());
-  const toggle = (id: string) =>
-    setOpen((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  return [open, toggle] as const;
-}
 
 /** Saved requests (load/reorder/rename) and saved responses (view/rename). */
 export function Saved({ onClose }: { onClose?: () => void }) {
@@ -28,8 +17,8 @@ export function Saved({ onClose }: { onClose?: () => void }) {
   const deleteSavedResponse = useStore((s) => s.deleteSavedResponse);
   const renameSavedResponse = useStore((s) => s.renameSavedResponse);
 
-  const [openReq, toggleReq] = useToggle();
-  const [openResp, toggleResp] = useToggle();
+  const [openReq, toggleReq] = useSetToggle();
+  const [openResp, toggleResp] = useSetToggle();
 
   const rename = (current: string, apply: (name: string) => void) => {
     const name = window.prompt('Rename:', current)?.trim();
@@ -48,15 +37,7 @@ export function Saved({ onClose }: { onClose?: () => void }) {
               return (
                 <li key={req.id} className="sb-saved__row">
                   <div className="sb-saved__item">
-                    <button
-                      type="button"
-                      className="sb-params__caret"
-                      aria-expanded={open}
-                      aria-label={open ? 'Collapse params' : 'Show params'}
-                      onClick={() => toggleReq(req.id)}
-                    >
-                      {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    </button>
+                    <CollapseCaret open={open} onToggle={() => toggleReq(req.id)} name="params" />
                     <button
                       type="button"
                       className="sb-saved__load"
@@ -132,15 +113,7 @@ export function Saved({ onClose }: { onClose?: () => void }) {
               return (
                 <li key={resp.id} className="sb-saved__row">
                   <div className="sb-saved__item">
-                    <button
-                      type="button"
-                      className="sb-params__caret"
-                      aria-expanded={open}
-                      aria-label={open ? 'Hide response' : 'Show response'}
-                      onClick={() => toggleResp(resp.id)}
-                    >
-                      {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    </button>
+                    <CollapseCaret open={open} onToggle={() => toggleResp(resp.id)} name="response" />
                     <button type="button" className="sb-saved__load" onClick={() => toggleResp(resp.id)}>
                       <span className="sb-saved__name">{resp.name}</span>
                       <Badge bg="secondary" className="ms-2">

--- a/src/components/Saved.tsx
+++ b/src/components/Saved.tsx
@@ -1,46 +1,184 @@
-import { Badge, Button } from 'react-bootstrap';
-import { Trash } from 'react-bootstrap-icons';
+import { useState } from 'react';
+import { Badge, Button, Tab, Tabs } from 'react-bootstrap';
+import { ArrowDown, ArrowUp, ChevronDown, ChevronRight, Pencil, Trash } from 'react-bootstrap-icons';
 
 import { useStore } from '../store/store';
+import { JsonViewer } from './JsonViewer';
 
-/** Saved requests: load a stored request into the form, or delete it. */
+function useToggle() {
+  const [open, setOpen] = useState<ReadonlySet<string>>(new Set());
+  const toggle = (id: string) =>
+    setOpen((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  return [open, toggle] as const;
+}
+
+/** Saved requests (load/reorder/rename) and saved responses (view/rename). */
 export function Saved({ onClose }: { onClose?: () => void }) {
   const saved = useStore((s) => s.saved);
   const deleteSaved = useStore((s) => s.deleteSaved);
+  const renameSaved = useStore((s) => s.renameSaved);
+  const moveSaved = useStore((s) => s.moveSaved);
   const prefillRequest = useStore((s) => s.prefillRequest);
+  const savedResponses = useStore((s) => s.savedResponses);
+  const deleteSavedResponse = useStore((s) => s.deleteSavedResponse);
+  const renameSavedResponse = useStore((s) => s.renameSavedResponse);
 
-  if (saved.length === 0) {
-    return <p className="sb-muted mb-0">No saved requests yet. Use “Save” in the method form.</p>;
-  }
+  const [openReq, toggleReq] = useToggle();
+  const [openResp, toggleResp] = useToggle();
+
+  const rename = (current: string, apply: (name: string) => void) => {
+    const name = window.prompt('Rename:', current)?.trim();
+    if (name) apply(name);
+  };
 
   return (
-    <ul className="sb-saved">
-      {[...saved].reverse().map((req) => (
-        <li key={req.id} className="sb-saved__item">
-          <button
-            type="button"
-            className="sb-saved__load"
-            onClick={() => {
-              prefillRequest(req.method, req.params);
-              onClose?.();
-            }}
-          >
-            <span className="sb-saved__name">{req.name}</span>
-            <Badge bg="secondary" className="ms-2">
-              {req.method}
-            </Badge>
-          </button>
-          <Button
-            size="sm"
-            variant="outline-danger"
-            onClick={() => deleteSaved(req.id)}
-            aria-label="Delete saved request"
-            title="Delete"
-          >
-            <Trash />
-          </Button>
-        </li>
-      ))}
-    </ul>
+    <Tabs defaultActiveKey="requests" className="mb-3">
+      <Tab eventKey="requests" title={`Requests${saved.length ? ` (${saved.length})` : ''}`}>
+        {saved.length === 0 ? (
+          <p className="sb-muted mb-0">No saved requests yet. Use “Save” in the method form.</p>
+        ) : (
+          <ul className="sb-saved">
+            {saved.map((req, i) => {
+              const open = openReq.has(req.id);
+              return (
+                <li key={req.id} className="sb-saved__row">
+                  <div className="sb-saved__item">
+                    <button
+                      type="button"
+                      className="sb-params__caret"
+                      aria-expanded={open}
+                      aria-label={open ? 'Collapse params' : 'Show params'}
+                      onClick={() => toggleReq(req.id)}
+                    >
+                      {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    </button>
+                    <button
+                      type="button"
+                      className="sb-saved__load"
+                      onClick={() => {
+                        prefillRequest(req.method, req.params);
+                        onClose?.();
+                      }}
+                    >
+                      <span className="sb-saved__name">{req.name}</span>
+                      <Badge bg="secondary" className="ms-2">
+                        {req.method}
+                      </Badge>
+                    </button>
+                    <div className="sb-saved__actions">
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        onClick={() => moveSaved(req.id, -1)}
+                        disabled={i === 0}
+                        aria-label="Move up"
+                        title="Move up"
+                      >
+                        <ArrowUp />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        onClick={() => moveSaved(req.id, 1)}
+                        disabled={i === saved.length - 1}
+                        aria-label="Move down"
+                        title="Move down"
+                      >
+                        <ArrowDown />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        onClick={() => rename(req.name, (n) => renameSaved(req.id, n))}
+                        aria-label="Rename"
+                        title="Rename"
+                      >
+                        <Pencil />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline-danger"
+                        onClick={() => deleteSaved(req.id)}
+                        aria-label="Delete saved request"
+                        title="Delete"
+                      >
+                        <Trash />
+                      </Button>
+                    </div>
+                  </div>
+                  {open && <pre className="sb-saved__preview">{JSON.stringify(req.params, null, 2)}</pre>}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Tab>
+
+      <Tab
+        eventKey="responses"
+        title={`Responses${savedResponses.length ? ` (${savedResponses.length})` : ''}`}
+      >
+        {savedResponses.length === 0 ? (
+          <p className="sb-muted mb-0">No saved responses yet. Use “Save” on a response.</p>
+        ) : (
+          <ul className="sb-saved">
+            {savedResponses.map((resp) => {
+              const open = openResp.has(resp.id);
+              return (
+                <li key={resp.id} className="sb-saved__row">
+                  <div className="sb-saved__item">
+                    <button
+                      type="button"
+                      className="sb-params__caret"
+                      aria-expanded={open}
+                      aria-label={open ? 'Hide response' : 'Show response'}
+                      onClick={() => toggleResp(resp.id)}
+                    >
+                      {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    </button>
+                    <button type="button" className="sb-saved__load" onClick={() => toggleResp(resp.id)}>
+                      <span className="sb-saved__name">{resp.name}</span>
+                      <Badge bg="secondary" className="ms-2">
+                        {resp.method}
+                      </Badge>
+                    </button>
+                    <div className="sb-saved__actions">
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        onClick={() => rename(resp.name, (n) => renameSavedResponse(resp.id, n))}
+                        aria-label="Rename"
+                        title="Rename"
+                      >
+                        <Pencil />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline-danger"
+                        onClick={() => deleteSavedResponse(resp.id)}
+                        aria-label="Delete saved response"
+                        title="Delete"
+                      >
+                        <Trash />
+                      </Button>
+                    </div>
+                  </div>
+                  {open && (
+                    <div className="sb-saved__preview-json">
+                      <JsonViewer json={resp.response} title={resp.name} />
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Tab>
+    </Tabs>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -89,7 +89,8 @@ function Group({ title, children }: { title?: string; children: React.ReactNode 
 /** Searchable, keyboard-navigable list of methods with favorites & recents. */
 export function Sidebar({ services }: { services: Record<string, SmdService> }) {
   const [search, setSearch] = useState('');
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const collapsedNamespaces = useStore((s) => s.collapsedNamespaces);
+  const toggleNamespace = useStore((s) => s.toggleNamespace);
   const favorites = useStore((s) => s.prefs.favorites);
   const history = useStore((s) => s.history);
   const grouped = useMemo(() => groupServices(services), [services]);
@@ -118,14 +119,6 @@ export function Sidebar({ services }: { services: Record<string, SmdService> }) 
       ),
     [grouped.namespaces, otherKeys, needle],
   );
-
-  const toggleCollapse = (ns: string) =>
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(ns)) next.delete(ns);
-      else next.add(ns);
-      return next;
-    });
 
   // Arrow-key navigation: from the search box into the list and across methods.
   const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -188,14 +181,14 @@ export function Sidebar({ services }: { services: Record<string, SmdService> }) 
         const filtered = filterMethods(methods, needle, ns);
         const keys = Object.keys(filtered);
         if (!keys.length) return null;
-        const isCollapsed = !searching && collapsed.has(ns);
+        const isCollapsed = !searching && collapsedNamespaces.includes(ns);
         return (
           <div className="sb-sidebar__namespace" key={ns}>
             <button
               type="button"
               className="h6 sb-sidebar__ns-title sb-sidebar__ns-toggle"
               aria-expanded={!isCollapsed}
-              onClick={() => toggleCollapse(ns)}
+              onClick={() => toggleNamespace(ns)}
             >
               <span className="sb-sidebar__caret">
                 {isCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}

--- a/src/components/paramTypes.ts
+++ b/src/components/paramTypes.ts
@@ -3,6 +3,8 @@
 /** A schema node shown in the params/returns tables (param, property, ...). */
 export interface DescNode {
   type?: string;
+  /** Concrete type name for objects (zenrpc emits the Go struct name here). */
+  typeName?: string;
   description?: string;
   optional?: boolean;
   $ref?: string;
@@ -26,13 +28,16 @@ export function referencedTypeName(node: DescNode): string {
   return '';
 }
 
-/** Human-readable type label, mirroring the legacy resolveType logic. */
+/** Human-readable type label: prefers concrete type names over bare `object`. */
 export function resolveType(node: DescNode): string {
   if (node.type === 'array') {
     return `[]${node.items?.type ?? refName(node.items?.['$ref']) ?? ''}`;
   }
-  if (node.type === 'object' && node.$ref) {
+  if (node.$ref) {
     return refName(node.$ref);
+  }
+  if (node.type === 'object' && node.typeName) {
+    return node.typeName;
   }
   return node.type ?? '';
 }

--- a/src/components/paramTypes.ts
+++ b/src/components/paramTypes.ts
@@ -8,10 +8,22 @@ export interface DescNode {
   $ref?: string;
   items?: Record<string, string>;
   properties?: Record<string, DescNode>;
+  /** Allowed values, when the schema enumerates them. */
+  enum?: unknown[];
 }
 
 function refName(ref?: string): string {
   return ref ? (ref.split('/').pop() ?? '') : '';
+}
+
+/**
+ * Name of the definition this node references (directly or as array items),
+ * or '' when it is not a reference. Used to inline nested type definitions.
+ */
+export function referencedTypeName(node: DescNode): string {
+  if (node.type === 'array') return refName(node.items?.['$ref']);
+  if (node.$ref) return refName(node.$ref);
+  return '';
 }
 
 /** Human-readable type label, mirroring the legacy resolveType logic. */

--- a/src/hooks/useSetToggle.ts
+++ b/src/hooks/useSetToggle.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+/** A collapse/expand set with a toggle: tracks which string keys are "on". */
+export function useSetToggle() {
+  const [set, setSet] = useState<ReadonlySet<string>>(new Set());
+  const toggle = (key: string) =>
+    setSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  return [set, toggle] as const;
+}

--- a/src/lib/__tests__/curl.test.ts
+++ b/src/lib/__tests__/curl.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { toCurl } from '../curl';
+import { fromCurl, toCurl } from '../curl';
 
 const body = { id: '1', jsonrpc: '2.0', method: 'Sum', params: { a: 1, b: 2 } };
 
@@ -20,5 +20,50 @@ describe('toCurl', () => {
   it('escapes single quotes in values', () => {
     const out = toCurl('/rpc', {}, { v: "a'b" });
     expect(out).toContain(`'\\''`);
+  });
+});
+
+describe('fromCurl', () => {
+  it('returns null for non-curl text', () => {
+    expect(fromCurl('{"jsonrpc":"2.0"}')).toBeNull();
+  });
+
+  it('round-trips a command produced by toCurl', () => {
+    const cmd = toCurl('https://api.example.com/rpc', { Authorization: 'Bearer x' }, body);
+    const parsed = fromCurl(cmd);
+    expect(parsed?.url).toBe('https://api.example.com/rpc');
+    expect(parsed?.headers.Authorization).toBe('Bearer x');
+    expect(parsed?.headers['Content-Type']).toBe('application/json');
+    expect(parsed?.body).toEqual(body);
+  });
+
+  it('parses a single-line command with --data and double quotes', () => {
+    const cmd =
+      'curl -X POST "https://api.example.com/rpc" -H "Content-Type: application/json" --data "{\\"method\\":\\"user.Get\\",\\"params\\":{\\"id\\":5}}"';
+    const parsed = fromCurl(cmd);
+    expect(parsed?.url).toBe('https://api.example.com/rpc');
+    expect(parsed?.body).toEqual({ method: 'user.Get', params: { id: 5 } });
+  });
+
+  it('handles multi-line commands with backslash continuations', () => {
+    const cmd = `curl 'https://api.example.com/rpc' \\
+  -H 'Content-Type: application/json' \\
+  -d '{"method":"Sum","params":{"a":1}}'`;
+    const parsed = fromCurl(cmd);
+    expect(parsed?.url).toBe('https://api.example.com/rpc');
+    expect(parsed?.body).toEqual({ method: 'Sum', params: { a: 1 } });
+  });
+
+  it('skips unrelated flags and ignores -X', () => {
+    const cmd = "curl -sS -L --compressed -u user:pass -X POST 'https://x/rpc' -d '{\"params\":{}}'";
+    const parsed = fromCurl(cmd);
+    expect(parsed?.url).toBe('https://x/rpc');
+    expect(parsed?.body).toEqual({ params: {} });
+  });
+
+  it('returns body undefined for a non-JSON payload', () => {
+    const parsed = fromCurl("curl 'https://x/rpc' -d 'not json'");
+    expect(parsed?.url).toBe('https://x/rpc');
+    expect(parsed?.body).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/idLinks.test.ts
+++ b/src/lib/__tests__/idLinks.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+
+import { idLinkUrl } from '../idLinks';
+
+const rules = {
+  showId: 'https://myshows.me/view/{id}/',
+  movieId: 'https://myshows.me/movie/{id}/',
+  newsId: 'https://myshows.me/news/{id}/',
+  productId: 'https://example.com/product/{id}',
+};
+
+describe('idLinkUrl', () => {
+  it('matches the leaf key directly', () => {
+    expect(idLinkUrl(['showId'], 35595, rules)).toBe('https://myshows.me/view/35595/');
+    expect(idLinkUrl(['productId'], 262423, rules)).toBe('https://example.com/product/262423');
+  });
+
+  it('accepts string values', () => {
+    expect(idLinkUrl(['movieId'], '1', rules)).toBe('https://myshows.me/movie/1/');
+  });
+
+  it('matches field names case-insensitively', () => {
+    expect(idLinkUrl(['MovieID'], 1, rules)).toBe('https://myshows.me/movie/1/');
+    expect(idLinkUrl(['ID', 'Movie'], 1, rules)).toBe('https://myshows.me/movie/1/');
+  });
+
+  it('treats a bare id under an entity object as that entity id', () => {
+    expect(idLinkUrl(['id', 'movie'], 1, rules)).toBe('https://myshows.me/movie/1/');
+    expect(idLinkUrl(['id', 'news'], 12514, rules)).toBe('https://myshows.me/news/12514/');
+  });
+
+  it('singularizes a plural parent key (movies[].id -> movieId)', () => {
+    expect(idLinkUrl(['id', 0, 'movies'], 1, rules)).toBe('https://myshows.me/movie/1/');
+    expect(idLinkUrl(['id', 3, 'shows'], 42, rules)).toBe('https://myshows.me/view/42/');
+  });
+
+  it('returns null for unknown fields and bare id without a matching parent', () => {
+    expect(idLinkUrl(['title'], 5, rules)).toBeNull();
+    expect(idLinkUrl(['id', 'person'], 9, rules)).toBeNull();
+  });
+
+  it('returns null for non-scalar or empty values', () => {
+    expect(idLinkUrl(['showId'], { a: 1 }, rules)).toBeNull();
+    expect(idLinkUrl(['showId'], null, rules)).toBeNull();
+    expect(idLinkUrl(['showId'], '', rules)).toBeNull();
+  });
+
+  it('appends the value when the template has no placeholder', () => {
+    expect(idLinkUrl(['x'], 7, { x: 'https://e/x/' })).toBe('https://e/x/7');
+  });
+
+  it('url-encodes the value', () => {
+    expect(idLinkUrl(['x'], 'a b', { x: 'https://e/{id}' })).toBe('https://e/a%20b');
+  });
+});

--- a/src/lib/__tests__/idLinks.test.ts
+++ b/src/lib/__tests__/idLinks.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
 
-import { idLinkUrl } from '../idLinks';
+import { idLinkUrl, lowerRuleKeys } from '../idLinks';
 
-const rules = {
+// idLinkUrl matches against a lowercased rule map (built once by callers).
+const rules = lowerRuleKeys({
   showId: 'https://myshows.me/view/{id}/',
   movieId: 'https://myshows.me/movie/{id}/',
   newsId: 'https://myshows.me/news/{id}/',
   productId: 'https://example.com/product/{id}',
-};
+});
 
 describe('idLinkUrl', () => {
   it('matches the leaf key directly', () => {

--- a/src/lib/__tests__/idLinks.test.ts
+++ b/src/lib/__tests__/idLinks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { idLinkUrl, lowerRuleKeys } from '../idLinks';
+import { idLinkUrl, lowerRuleKeys, urlValue } from '../idLinks';
 
 // idLinkUrl matches against a lowercased rule map (built once by callers).
 const rules = lowerRuleKeys({
@@ -52,5 +52,19 @@ describe('idLinkUrl', () => {
 
   it('url-encodes the value', () => {
     expect(idLinkUrl(['x'], 'a b', { x: 'https://e/{id}' })).toBe('https://e/a%20b');
+  });
+});
+
+describe('urlValue', () => {
+  it('detects http(s) URL string values', () => {
+    expect(urlValue('https://example.com/a/b')).toBe('https://example.com/a/b');
+    expect(urlValue('http://x.io')).toBe('http://x.io');
+  });
+
+  it('returns null for non-URL or non-string values', () => {
+    expect(urlValue('just text')).toBeNull();
+    expect(urlValue('ftp://x')).toBeNull();
+    expect(urlValue(42)).toBeNull();
+    expect(urlValue('https://has space')).toBeNull();
   });
 });

--- a/src/lib/curl.ts
+++ b/src/lib/curl.ts
@@ -14,3 +14,127 @@ export function toCurl(endpoint: string, headers: Record<string, string>, body: 
   lines.push(`  -d ${shellQuote(JSON.stringify(body))}`);
   return lines.join(' \\\n');
 }
+
+/** Result of parsing a curl command. */
+export interface ParsedCurl {
+  url?: string;
+  headers: Record<string, string>;
+  /** Parsed JSON request body (undefined when absent or not JSON). */
+  body?: unknown;
+}
+
+/** Splits a shell command into tokens, honoring quotes and line continuations. */
+function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let cur = '';
+  let started = false;
+  let i = 0;
+  while (i < input.length) {
+    const c = input[i];
+    if (c === undefined) break;
+    // Line continuation: backslash followed by (CR)LF.
+    if (c === '\\' && (input[i + 1] === '\n' || input[i + 1] === '\r')) {
+      i += input[i + 1] === '\r' && input[i + 2] === '\n' ? 3 : 2;
+      continue;
+    }
+    // ANSI-C / locale quoting: drop the leading $ before a quote ($'…', $"…").
+    if (c === '$' && (input[i + 1] === "'" || input[i + 1] === '"')) {
+      i += 1;
+      continue;
+    }
+    if (c === "'") {
+      started = true;
+      i += 1;
+      while (i < input.length && input[i] !== "'") cur += input[i++];
+      i += 1; // closing quote
+      continue;
+    }
+    if (c === '"') {
+      started = true;
+      i += 1;
+      while (i < input.length && input[i] !== '"') {
+        if (input[i] === '\\' && i + 1 < input.length) {
+          cur += input[i + 1];
+          i += 2;
+        } else {
+          cur += input[i++];
+        }
+      }
+      i += 1; // closing quote
+      continue;
+    }
+    if (/\s/.test(c)) {
+      if (started) {
+        tokens.push(cur);
+        cur = '';
+        started = false;
+      }
+      i += 1;
+      continue;
+    }
+    started = true;
+    cur += c;
+    i += 1;
+  }
+  if (started) tokens.push(cur);
+  return tokens;
+}
+
+// Flags that consume the next token but that we don't otherwise use.
+const SKIP_VALUE_FLAGS = new Set([
+  '-u', '--user', '-A', '--user-agent', '-e', '--referer', '-b', '--cookie',
+  '-o', '--output', '-T', '--upload-file', '--connect-timeout', '--max-time', '-m',
+]);
+const DATA_FLAGS = new Set(['-d', '--data', '--data-raw', '--data-binary', '--data-ascii', '--data-urlencode']);
+
+/**
+ * Parses a `curl` command into its URL, headers and JSON body. Returns null
+ * when the text is not a curl command or carries nothing usable.
+ */
+export function fromCurl(text: string): ParsedCurl | null {
+  if (!/^\s*curl\b/.test(text)) return null;
+  const tokens = tokenize(text.trim());
+  const headers: Record<string, string> = {};
+  let url: string | undefined;
+  let rawBody: string | undefined;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === undefined) continue;
+    if (t === '-X' || t === '--request') {
+      i += 1; // method is implied by the JSON-RPC body
+      continue;
+    }
+    if (t === '-H' || t === '--header') {
+      const h = tokens[++i] ?? '';
+      const idx = h.indexOf(':');
+      if (idx > 0) headers[h.slice(0, idx).trim()] = h.slice(idx + 1).trim();
+      continue;
+    }
+    if (DATA_FLAGS.has(t)) {
+      rawBody = tokens[++i];
+      continue;
+    }
+    if (t === '--url') {
+      url = tokens[++i];
+      continue;
+    }
+    if (SKIP_VALUE_FLAGS.has(t)) {
+      i += 1;
+      continue;
+    }
+    if (t.startsWith('-')) continue; // valueless or unknown flag
+    if (!url) url = t; // first bare token is the URL
+  }
+
+  let body: unknown;
+  if (rawBody !== undefined) {
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      body = undefined;
+    }
+  }
+  if (url === undefined && body === undefined) return null;
+  return { url, headers, body };
+}

--- a/src/lib/curl.ts
+++ b/src/lib/curl.ts
@@ -23,6 +23,15 @@ export interface ParsedCurl {
   body?: unknown;
 }
 
+/** Extracts a JSON-RPC `params` object from a parsed request body, or null. */
+export function rpcParams(body: unknown): Record<string, unknown> | null {
+  const params = (body as { params?: unknown } | null | undefined)?.params;
+  if (params && typeof params === 'object' && !Array.isArray(params)) {
+    return params as Record<string, unknown>;
+  }
+  return null;
+}
+
 /** Splits a shell command into tokens, honoring quotes and line continuations. */
 function tokenize(input: string): string[] {
   const tokens: string[] = [];

--- a/src/lib/idLinks.ts
+++ b/src/lib/idLinks.ts
@@ -7,27 +7,31 @@ function build(template: string, raw: string): string {
   return template + encoded;
 }
 
+/** Lowercases rule keys once so `idLinkUrl` can match case-insensitively cheaply. */
+export function lowerRuleKeys(rules: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, template] of Object.entries(rules)) out[key.toLowerCase()] = template;
+  return out;
+}
+
 /**
  * Builds the URL for a leaf value given its key path (leaf-first, as react-json-tree
  * provides it), or null when no rule matches or the value is not a usable scalar.
  *
- * A rule matches either the leaf key directly (e.g. `movieId`), or — when the leaf
- * is a bare `id` — the parent entity key plus `Id` (e.g. `movie.id` or `movies[].id`
- * → `movieId`). The template may use `{id}`/`{value}`; with no placeholder the value
- * is appended.
+ * `lowerRules` must already be keyed by lowercased field name (see `lowerRuleKeys`);
+ * it is matched case-insensitively. A rule matches either the leaf key directly
+ * (e.g. `movieId`), or — when the leaf is a bare `id` — the parent entity key plus
+ * `Id` (e.g. `movie.id` or `movies[].id` → `movieId`). The template may use
+ * `{id}`/`{value}`; with no placeholder the value is appended.
  */
 export function idLinkUrl(
   keyPath: ReadonlyArray<string | number>,
   value: unknown,
-  rules: Record<string, string>,
+  lowerRules: Record<string, string>,
 ): string | null {
   if (typeof value !== 'string' && typeof value !== 'number') return null;
   const raw = String(value);
   if (raw === '') return null;
-
-  // Field names match case-insensitively.
-  const byLower: Record<string, string> = {};
-  for (const [key, template] of Object.entries(rules)) byLower[key.toLowerCase()] = template;
 
   const leaf = String(keyPath[0] ?? '');
   const candidates = [leaf];
@@ -42,7 +46,7 @@ export function idLinkUrl(
   }
 
   for (const field of candidates) {
-    const template = byLower[field.toLowerCase()];
+    const template = lowerRules[field.toLowerCase()];
     if (template) return build(template, raw);
   }
   return null;

--- a/src/lib/idLinks.ts
+++ b/src/lib/idLinks.ts
@@ -7,6 +7,13 @@ function build(template: string, raw: string): string {
   return template + encoded;
 }
 
+const HTTP_URL_RE = /^https?:\/\/[^\s"']+$/i;
+
+/** Returns the value itself when it is already an http(s) URL string, else null. */
+export function urlValue(value: unknown): string | null {
+  return typeof value === 'string' && HTTP_URL_RE.test(value) ? value : null;
+}
+
 /** Lowercases rule keys once so `idLinkUrl` can match case-insensitively cheaply. */
 export function lowerRuleKeys(rules: Record<string, string>): Record<string, string> {
   const out: Record<string, string> = {};

--- a/src/lib/idLinks.ts
+++ b/src/lib/idLinks.ts
@@ -1,0 +1,49 @@
+/** Turns id values in responses into links via field-name -> URL-template rules. */
+
+function build(template: string, raw: string): string {
+  const encoded = encodeURIComponent(raw);
+  if (template.includes('{id}')) return template.replace(/\{id\}/g, encoded);
+  if (template.includes('{value}')) return template.replace(/\{value\}/g, encoded);
+  return template + encoded;
+}
+
+/**
+ * Builds the URL for a leaf value given its key path (leaf-first, as react-json-tree
+ * provides it), or null when no rule matches or the value is not a usable scalar.
+ *
+ * A rule matches either the leaf key directly (e.g. `movieId`), or — when the leaf
+ * is a bare `id` — the parent entity key plus `Id` (e.g. `movie.id` or `movies[].id`
+ * → `movieId`). The template may use `{id}`/`{value}`; with no placeholder the value
+ * is appended.
+ */
+export function idLinkUrl(
+  keyPath: ReadonlyArray<string | number>,
+  value: unknown,
+  rules: Record<string, string>,
+): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const raw = String(value);
+  if (raw === '') return null;
+
+  // Field names match case-insensitively.
+  const byLower: Record<string, string> = {};
+  for (const [key, template] of Object.entries(rules)) byLower[key.toLowerCase()] = template;
+
+  const leaf = String(keyPath[0] ?? '');
+  const candidates = [leaf];
+  // A bare `id` inside a `movie`/`show`/... object is that entity's primary key.
+  if (leaf.toLowerCase() === 'id') {
+    const parent = keyPath.slice(1).find((k) => typeof k === 'string');
+    if (typeof parent === 'string' && parent) {
+      candidates.push(`${parent}Id`);
+      const singular = parent.replace(/s$/i, '');
+      if (singular && singular !== parent) candidates.push(`${singular}Id`);
+    }
+  }
+
+  for (const field of candidates) {
+    const template = byLower[field.toLowerCase()];
+    if (template) return build(template, raw);
+  }
+  return null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,6 +26,8 @@ export interface SmdboxOptions {
   selector?: string;
   /** Knowledge-base link shown on the setup screen (defaults to the smdbox repo). */
   docsUrl?: string;
+  /** Field name -> URL template (with `{id}`) to turn ids in responses into links. */
+  idLinks?: Record<string, string>;
 }
 
 const DEFAULT_SELECTOR = '#smdbox-root';
@@ -48,11 +50,13 @@ async function init(options: SmdboxOptions = {}): Promise<void> {
     endpoint: string;
     headers: Record<string, string>;
     docsUrl: string;
+    idLinks: Record<string, string>;
   }> = {};
   if (options.smdUrl) pre.smdUrl = options.smdUrl;
   if (options.endpoint) pre.endpoint = options.endpoint;
   if (options.headers && Object.keys(options.headers).length) pre.headers = options.headers;
   if (options.docsUrl) pre.docsUrl = options.docsUrl;
+  if (options.idLinks && Object.keys(options.idLinks).length) pre.idLinks = options.idLinks;
   if (Object.keys(pre).length) useStore.getState().preconfigure(pre);
 
   startPersistence();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,8 @@ export interface SmdboxOptions {
   headers?: Record<string, string>;
   /** CSS selector of the element smdbox mounts into. */
   selector?: string;
+  /** Knowledge-base link shown on the setup screen (defaults to the smdbox repo). */
+  docsUrl?: string;
 }
 
 const DEFAULT_SELECTOR = '#smdbox-root';
@@ -41,10 +43,16 @@ async function init(options: SmdboxOptions = {}): Promise<void> {
   const persisted = await readState<PersistedState>().catch(() => null);
   if (persisted) useStore.getState().hydrate(persisted);
 
-  const pre: Partial<{ smdUrl: string; endpoint: string; headers: Record<string, string> }> = {};
+  const pre: Partial<{
+    smdUrl: string;
+    endpoint: string;
+    headers: Record<string, string>;
+    docsUrl: string;
+  }> = {};
   if (options.smdUrl) pre.smdUrl = options.smdUrl;
   if (options.endpoint) pre.endpoint = options.endpoint;
   if (options.headers && Object.keys(options.headers).length) pre.headers = options.headers;
+  if (options.docsUrl) pre.docsUrl = options.docsUrl;
   if (Object.keys(pre).length) useStore.getState().preconfigure(pre);
 
   startPersistence();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { App } from './app/App';
 import { queryClient } from './data/queries';
 import { readState } from './lib/persist';
-import { startPersistence, useStore, type PersistedState } from './store/store';
+import { startPersistence, useStore, type PersistedState, type Preset } from './store/store';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './design/tokens.css';
@@ -28,6 +28,8 @@ export interface SmdboxOptions {
   docsUrl?: string;
   /** Field name -> URL template (with `{id}`) to turn ids in responses into links. */
   idLinks?: Record<string, string>;
+  /** Ready-made connections offered as one-click presets on the setup screen. */
+  presets?: Preset[];
 }
 
 const DEFAULT_SELECTOR = '#smdbox-root';
@@ -51,12 +53,14 @@ async function init(options: SmdboxOptions = {}): Promise<void> {
     headers: Record<string, string>;
     docsUrl: string;
     idLinks: Record<string, string>;
+    presets: Preset[];
   }> = {};
   if (options.smdUrl) pre.smdUrl = options.smdUrl;
   if (options.endpoint) pre.endpoint = options.endpoint;
   if (options.headers && Object.keys(options.headers).length) pre.headers = options.headers;
   if (options.docsUrl) pre.docsUrl = options.docsUrl;
   if (options.idLinks && Object.keys(options.idLinks).length) pre.idLinks = options.idLinks;
+  if (options.presets && options.presets.length) pre.presets = options.presets;
   if (Object.keys(pre).length) useStore.getState().preconfigure(pre);
 
   startPersistence();

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -106,7 +106,7 @@ export interface AppState extends PersistedState {
     navbarColor?: string;
     theme?: Theme;
   }): void;
-  /** Snapshot the current project config as a named environment. */
+  /** Save the current project config as a named env (upsert by name) and select it. */
   saveEnvironment(name: string): void;
   applyEnvironment(id: string): void;
   renameEnvironment(id: string, name: string): void;
@@ -155,7 +155,19 @@ export const useStore = create<AppState>((set) => ({
     })),
 
   updateSettings: ({ endpoint, headers }) =>
-    set((s) => ({ project: { ...s.project, endpoint, headers }, activeEnvironmentId: null })),
+    set((s) => {
+      const project = { ...s.project, endpoint, headers };
+      // Keep the active environment selected and in sync: editing settings
+      // updates that env in place instead of silently detaching from it.
+      const environments = s.activeEnvironmentId
+        ? s.environments.map((e) =>
+            e.id === s.activeEnvironmentId
+              ? { ...e, endpoint, headers, smdUrl: project.smdUrl }
+              : e,
+          )
+        : s.environments;
+      return { project, environments };
+    }),
 
   clearProject: () => set({ project: initialProject, selected: null, activeEnvironmentId: null }),
 
@@ -204,18 +216,27 @@ export const useStore = create<AppState>((set) => ({
     }),
 
   saveEnvironment: (name) =>
-    set((s) => ({
-      environments: [
-        ...s.environments,
-        {
-          id: crypto.randomUUID(),
-          name,
-          endpoint: s.project.endpoint,
-          smdUrl: s.project.smdUrl,
-          headers: s.project.headers,
-        },
-      ],
-    })),
+    set((s) => {
+      const trimmed = name.trim();
+      const snapshot = {
+        endpoint: s.project.endpoint,
+        smdUrl: s.project.smdUrl,
+        headers: s.project.headers,
+      };
+      // Saving under an existing name updates that env (no duplicate); select it either way.
+      const existing = s.environments.find((e) => e.name === trimmed);
+      if (existing) {
+        return {
+          environments: s.environments.map((e) => (e.id === existing.id ? { ...e, ...snapshot } : e)),
+          activeEnvironmentId: existing.id,
+        };
+      }
+      const id = crypto.randomUUID();
+      return {
+        environments: [...s.environments, { id, name: trimmed, ...snapshot }],
+        activeEnvironmentId: id,
+      };
+    }),
 
   applyEnvironment: (id) =>
     set((s) => {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -62,6 +62,8 @@ export interface PersistedState {
   activeEnvironmentId: string | null;
   /** Sidebar namespaces the user has collapsed (default: all expanded). */
   collapsedNamespaces: string[];
+  /** Field name -> URL template (with {id}); turns ids in responses into links. */
+  idLinks: Record<string, string>;
 }
 
 export interface AppState extends PersistedState {
@@ -71,7 +73,10 @@ export interface AppState extends PersistedState {
   docsUrl: string;
   /** Apply preconfigured values from window.smdbox(options); options win. */
   preconfigure(
-    partial: Partial<Pick<ProjectConfig, 'endpoint' | 'smdUrl' | 'headers'>> & { docsUrl?: string },
+    partial: Partial<Pick<ProjectConfig, 'endpoint' | 'smdUrl' | 'headers'>> & {
+      docsUrl?: string;
+      idLinks?: Record<string, string>;
+    },
   ): void;
   createProject(cfg: { endpoint: string; smdUrl: string; headers: Record<string, string> }): void;
   updateSettings(cfg: { endpoint: string; headers: Record<string, string> }): void;
@@ -102,6 +107,9 @@ export interface AppState extends PersistedState {
   deleteEnvironment(id: string): void;
   /** Collapse/expand a sidebar namespace (persisted). */
   toggleNamespace(ns: string): void;
+  /** Add or update an id->URL link rule. */
+  setIdLink(field: string, urlTemplate: string): void;
+  removeIdLink(field: string): void;
   hydrate(state: Partial<PersistedState>): void;
 }
 
@@ -123,11 +131,16 @@ export const useStore = create<AppState>((set) => ({
   environments: [],
   activeEnvironmentId: null,
   collapsedNamespaces: [],
+  idLinks: {},
   prefill: null,
   docsUrl: '',
 
-  preconfigure: ({ docsUrl, ...rest }) =>
-    set((s) => ({ project: { ...s.project, ...rest }, docsUrl: docsUrl ?? s.docsUrl })),
+  preconfigure: ({ docsUrl, idLinks, ...rest }) =>
+    set((s) => ({
+      project: { ...s.project, ...rest },
+      docsUrl: docsUrl ?? s.docsUrl,
+      idLinks: idLinks ? { ...s.idLinks, ...idLinks } : s.idLinks,
+    })),
 
   createProject: ({ endpoint, smdUrl, headers }) =>
     set((s) => ({
@@ -224,6 +237,16 @@ export const useStore = create<AppState>((set) => ({
         : [...s.collapsedNamespaces, ns],
     })),
 
+  setIdLink: (field, urlTemplate) =>
+    set((s) => ({ idLinks: { ...s.idLinks, [field]: urlTemplate } })),
+
+  removeIdLink: (field) =>
+    set((s) => {
+      const next = { ...s.idLinks };
+      delete next[field];
+      return { idLinks: next };
+    }),
+
   toggleTheme: () =>
     set((s) => ({ prefs: { ...s.prefs, theme: s.prefs.theme === 'dark' ? 'light' : 'dark' } })),
 
@@ -249,6 +272,7 @@ export const useStore = create<AppState>((set) => ({
       environments: state.environments ?? s.environments,
       activeEnvironmentId: state.activeEnvironmentId ?? s.activeEnvironmentId,
       collapsedNamespaces: state.collapsedNamespaces ?? s.collapsedNamespaces,
+      idLinks: state.idLinks ?? s.idLinks,
     })),
 }));
 
@@ -274,6 +298,7 @@ export function startPersistence(): void {
         environments,
         activeEnvironmentId,
         collapsedNamespaces,
+        idLinks,
       } = useStore.getState();
       void writeState({
         project,
@@ -284,6 +309,7 @@ export function startPersistence(): void {
         environments,
         activeEnvironmentId,
         collapsedNamespaces,
+        idLinks,
       } satisfies PersistedState);
     }, PERSIST_DEBOUNCE_MS);
   });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -47,6 +47,8 @@ export interface Environment {
   endpoint: string | null;
   smdUrl: string | null;
   headers: Record<string, string>;
+  /** Per-env navbar color; falls back to prefs.navbarColor when empty. */
+  color?: string;
 }
 
 /** A host-provided ready-made connection offered on the setup screen. */
@@ -285,6 +287,7 @@ export const useStore = create<AppState>((set) => ({
         endpoint: s.project.endpoint,
         smdUrl: s.project.smdUrl,
         headers: s.project.headers,
+        color: s.environments.find((e) => e.id === s.activeEnvironmentId)?.color ?? s.prefs.navbarColor,
       };
       // Saving under an existing name updates that env (no duplicate); select it either way.
       const existing = s.environments.find((e) => e.name === trimmed);
@@ -343,7 +346,19 @@ export const useStore = create<AppState>((set) => ({
   toggleTheme: () =>
     set((s) => ({ prefs: { ...s.prefs, theme: s.prefs.theme === 'dark' ? 'light' : 'dark' } })),
 
-  setNavbarColor: (color) => set((s) => ({ prefs: { ...s.prefs, navbarColor: color } })),
+  setNavbarColor: (color) =>
+    set((s) => {
+      // While an environment is active, color binds to that env (so switching
+      // envs changes the navbar); otherwise it sets the global fallback.
+      if (s.activeEnvironmentId) {
+        return {
+          environments: s.environments.map((e) =>
+            e.id === s.activeEnvironmentId ? { ...e, color } : e,
+          ),
+        };
+      }
+      return { prefs: { ...s.prefs, navbarColor: color } };
+    }),
 
   toggleFavorite: (name) =>
     set((s) => ({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -91,7 +91,10 @@ export interface AppState extends PersistedState {
   clearPrefill(): void;
   saveRequest(name: string, method: string, params: JsonRpcParams): void;
   deleteSaved(id: string): void;
-  /** Import a config bundle: connection + favorites + saved + environments (merged). */
+  /**
+   * Import a config bundle: connection + favorites + saved + environments +
+   * id links + appearance (theme/navbar color), all merged into current state.
+   */
   importConfig(cfg: {
     endpoint?: string;
     smdUrl?: string;
@@ -99,6 +102,9 @@ export interface AppState extends PersistedState {
     favorites?: string[];
     saved?: SavedRequest[];
     environments?: Environment[];
+    idLinks?: Record<string, string>;
+    navbarColor?: string;
+    theme?: Theme;
   }): void;
   /** Snapshot the current project config as a named environment. */
   saveEnvironment(name: string): void;
@@ -188,9 +194,12 @@ export const useStore = create<AppState>((set) => ({
         prefs: {
           ...s.prefs,
           favorites: Array.from(new Set([...s.prefs.favorites, ...(cfg.favorites ?? [])])),
+          navbarColor: cfg.navbarColor ?? s.prefs.navbarColor,
+          theme: cfg.theme ?? s.prefs.theme,
         },
         saved: mergeById(s.saved, cfg.saved),
         environments: mergeById(s.environments, cfg.environments),
+        idLinks: cfg.idLinks ? { ...s.idLinks, ...cfg.idLinks } : s.idLinks,
       };
     }),
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -32,6 +32,14 @@ export interface SavedRequest {
   ts: number;
 }
 
+export interface SavedResponse {
+  id: string;
+  name: string;
+  method: string;
+  response: unknown;
+  ts: number;
+}
+
 /** A named project configuration (endpoint + schema + headers). */
 export interface Environment {
   id: string;
@@ -39,6 +47,14 @@ export interface Environment {
   endpoint: string | null;
   smdUrl: string | null;
   headers: Record<string, string>;
+}
+
+/** A host-provided ready-made connection offered on the setup screen. */
+export interface Preset {
+  name: string;
+  smdUrl: string;
+  endpoint?: string;
+  headers?: Record<string, string>;
 }
 
 export type Theme = 'light' | 'dark';
@@ -57,6 +73,7 @@ export interface PersistedState {
   history: HistoryItem[];
   prefs: Prefs;
   saved: SavedRequest[];
+  savedResponses: SavedResponse[];
   environments: Environment[];
   /** Id of the environment currently applied (null when config is manual). */
   activeEnvironmentId: string | null;
@@ -71,11 +88,14 @@ export interface AppState extends PersistedState {
   prefill: { method: string; params: JsonRpcParams } | null;
   /** Knowledge-base link; empty unless set via window.smdbox({ docsUrl }). Not persisted. */
   docsUrl: string;
+  /** Host-provided setup presets; empty unless set via window.smdbox({ presets }). Not persisted. */
+  presets: Preset[];
   /** Apply preconfigured values from window.smdbox(options); options win. */
   preconfigure(
     partial: Partial<Pick<ProjectConfig, 'endpoint' | 'smdUrl' | 'headers'>> & {
       docsUrl?: string;
       idLinks?: Record<string, string>;
+      presets?: Preset[];
     },
   ): void;
   createProject(cfg: { endpoint: string; smdUrl: string; headers: Record<string, string> }): void;
@@ -91,6 +111,12 @@ export interface AppState extends PersistedState {
   clearPrefill(): void;
   saveRequest(name: string, method: string, params: JsonRpcParams): void;
   deleteSaved(id: string): void;
+  renameSaved(id: string, name: string): void;
+  /** Move a saved request up (-1) or down (+1) in the list. */
+  moveSaved(id: string, dir: -1 | 1): void;
+  saveResponse(name: string, method: string, response: unknown): void;
+  deleteSavedResponse(id: string): void;
+  renameSavedResponse(id: string, name: string): void;
   /**
    * Import a config bundle: connection + favorites + saved + environments +
    * id links + appearance (theme/navbar color), all merged into current state.
@@ -101,6 +127,7 @@ export interface AppState extends PersistedState {
     headers?: Record<string, string>;
     favorites?: string[];
     saved?: SavedRequest[];
+    savedResponses?: SavedResponse[];
     environments?: Environment[];
     idLinks?: Record<string, string>;
     navbarColor?: string;
@@ -134,18 +161,21 @@ export const useStore = create<AppState>((set) => ({
   history: [],
   prefs: initialPrefs,
   saved: [],
+  savedResponses: [],
   environments: [],
   activeEnvironmentId: null,
   collapsedNamespaces: [],
   idLinks: {},
   prefill: null,
   docsUrl: '',
+  presets: [],
 
-  preconfigure: ({ docsUrl, idLinks, ...rest }) =>
+  preconfigure: ({ docsUrl, idLinks, presets, ...rest }) =>
     set((s) => ({
       project: { ...s.project, ...rest },
       docsUrl: docsUrl ?? s.docsUrl,
       idLinks: idLinks ? { ...s.idLinks, ...idLinks } : s.idLinks,
+      presets: presets ?? s.presets,
     })),
 
   createProject: ({ endpoint, smdUrl, headers }) =>
@@ -186,6 +216,38 @@ export const useStore = create<AppState>((set) => ({
 
   deleteSaved: (id) => set((s) => ({ saved: s.saved.filter((r) => r.id !== id) })),
 
+  renameSaved: (id, name) =>
+    set((s) => ({ saved: s.saved.map((r) => (r.id === id ? { ...r, name } : r)) })),
+
+  moveSaved: (id, dir) =>
+    set((s) => {
+      const i = s.saved.findIndex((r) => r.id === id);
+      const j = i + dir;
+      const a = s.saved[i];
+      const b = s.saved[j];
+      if (!a || !b) return {};
+      const next = [...s.saved];
+      next[i] = b;
+      next[j] = a;
+      return { saved: next };
+    }),
+
+  saveResponse: (name, method, response) =>
+    set((s) => ({
+      savedResponses: [
+        ...s.savedResponses,
+        { id: crypto.randomUUID(), name, method, response, ts: Date.now() },
+      ],
+    })),
+
+  deleteSavedResponse: (id) =>
+    set((s) => ({ savedResponses: s.savedResponses.filter((r) => r.id !== id) })),
+
+  renameSavedResponse: (id, name) =>
+    set((s) => ({
+      savedResponses: s.savedResponses.map((r) => (r.id === id ? { ...r, name } : r)),
+    })),
+
   importConfig: (cfg) =>
     set((s) => {
       const mergeById = <T extends { id: string }>(cur: T[], inc?: T[]): T[] => {
@@ -210,6 +272,7 @@ export const useStore = create<AppState>((set) => ({
           theme: cfg.theme ?? s.prefs.theme,
         },
         saved: mergeById(s.saved, cfg.saved),
+        savedResponses: mergeById(s.savedResponses, cfg.savedResponses),
         environments: mergeById(s.environments, cfg.environments),
         idLinks: cfg.idLinks ? { ...s.idLinks, ...cfg.idLinks } : s.idLinks,
       };
@@ -299,6 +362,7 @@ export const useStore = create<AppState>((set) => ({
       history: state.history ?? s.history,
       prefs: { ...s.prefs, ...(state.prefs ?? {}) },
       saved: state.saved ?? s.saved,
+      savedResponses: state.savedResponses ?? s.savedResponses,
       environments: state.environments ?? s.environments,
       activeEnvironmentId: state.activeEnvironmentId ?? s.activeEnvironmentId,
       collapsedNamespaces: state.collapsedNamespaces ?? s.collapsedNamespaces,
@@ -325,6 +389,7 @@ export function startPersistence(): void {
         history,
         prefs,
         saved,
+        savedResponses,
         environments,
         activeEnvironmentId,
         collapsedNamespaces,
@@ -336,6 +401,7 @@ export function startPersistence(): void {
         history,
         prefs,
         saved,
+        savedResponses,
         environments,
         activeEnvironmentId,
         collapsedNamespaces,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -46,6 +46,8 @@ export type Theme = 'light' | 'dark';
 export interface Prefs {
   theme: Theme;
   favorites: string[];
+  /** Navbar color override (hex); '' uses the default ocean. */
+  navbarColor: string;
 }
 
 /** Slice of the store that is persisted to IndexedDB. */
@@ -77,6 +79,7 @@ export interface AppState extends PersistedState {
   selectMethod(name: string | null): void;
   addHistory(item: HistoryItem): void;
   toggleTheme(): void;
+  setNavbarColor(color: string): void;
   toggleFavorite(name: string): void;
   /** Select a method and seed its form with the given params. */
   prefillRequest(method: string, params: JsonRpcParams): void;
@@ -109,7 +112,7 @@ const initialProject: ProjectConfig = {
   created: false,
 };
 
-const initialPrefs: Prefs = { theme: 'light', favorites: [] };
+const initialPrefs: Prefs = { theme: 'light', favorites: [], navbarColor: '' };
 
 export const useStore = create<AppState>((set) => ({
   project: initialProject,
@@ -223,6 +226,8 @@ export const useStore = create<AppState>((set) => ({
 
   toggleTheme: () =>
     set((s) => ({ prefs: { ...s.prefs, theme: s.prefs.theme === 'dark' ? 'light' : 'dark' } })),
+
+  setNavbarColor: (color) => set((s) => ({ prefs: { ...s.prefs, navbarColor: color } })),
 
   toggleFavorite: (name) =>
     set((s) => ({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -58,13 +58,19 @@ export interface PersistedState {
   environments: Environment[];
   /** Id of the environment currently applied (null when config is manual). */
   activeEnvironmentId: string | null;
+  /** Sidebar namespaces the user has collapsed (default: all expanded). */
+  collapsedNamespaces: string[];
 }
 
 export interface AppState extends PersistedState {
   /** Transient params to seed the next form mount (re-run / shared link). */
   prefill: { method: string; params: JsonRpcParams } | null;
+  /** Knowledge-base link; empty unless set via window.smdbox({ docsUrl }). Not persisted. */
+  docsUrl: string;
   /** Apply preconfigured values from window.smdbox(options); options win. */
-  preconfigure(partial: Partial<Pick<ProjectConfig, 'endpoint' | 'smdUrl' | 'headers'>>): void;
+  preconfigure(
+    partial: Partial<Pick<ProjectConfig, 'endpoint' | 'smdUrl' | 'headers'>> & { docsUrl?: string },
+  ): void;
   createProject(cfg: { endpoint: string; smdUrl: string; headers: Record<string, string> }): void;
   updateSettings(cfg: { endpoint: string; headers: Record<string, string> }): void;
   clearProject(): void;
@@ -89,7 +95,10 @@ export interface AppState extends PersistedState {
   /** Snapshot the current project config as a named environment. */
   saveEnvironment(name: string): void;
   applyEnvironment(id: string): void;
+  renameEnvironment(id: string, name: string): void;
   deleteEnvironment(id: string): void;
+  /** Collapse/expand a sidebar namespace (persisted). */
+  toggleNamespace(ns: string): void;
   hydrate(state: Partial<PersistedState>): void;
 }
 
@@ -110,9 +119,12 @@ export const useStore = create<AppState>((set) => ({
   saved: [],
   environments: [],
   activeEnvironmentId: null,
+  collapsedNamespaces: [],
   prefill: null,
+  docsUrl: '',
 
-  preconfigure: (partial) => set((s) => ({ project: { ...s.project, ...partial } })),
+  preconfigure: ({ docsUrl, ...rest }) =>
+    set((s) => ({ project: { ...s.project, ...rest }, docsUrl: docsUrl ?? s.docsUrl })),
 
   createProject: ({ endpoint, smdUrl, headers }) =>
     set((s) => ({
@@ -191,10 +203,22 @@ export const useStore = create<AppState>((set) => ({
       };
     }),
 
+  renameEnvironment: (id, name) =>
+    set((s) => ({
+      environments: s.environments.map((e) => (e.id === id ? { ...e, name } : e)),
+    })),
+
   deleteEnvironment: (id) =>
     set((s) => ({
       environments: s.environments.filter((e) => e.id !== id),
       activeEnvironmentId: s.activeEnvironmentId === id ? null : s.activeEnvironmentId,
+    })),
+
+  toggleNamespace: (ns) =>
+    set((s) => ({
+      collapsedNamespaces: s.collapsedNamespaces.includes(ns)
+        ? s.collapsedNamespaces.filter((n) => n !== ns)
+        : [...s.collapsedNamespaces, ns],
     })),
 
   toggleTheme: () =>
@@ -219,6 +243,7 @@ export const useStore = create<AppState>((set) => ({
       saved: state.saved ?? s.saved,
       environments: state.environments ?? s.environments,
       activeEnvironmentId: state.activeEnvironmentId ?? s.activeEnvironmentId,
+      collapsedNamespaces: state.collapsedNamespaces ?? s.collapsedNamespaces,
     })),
 }));
 
@@ -235,8 +260,16 @@ export function startPersistence(): void {
     scheduled = true;
     setTimeout(() => {
       scheduled = false;
-      const { project, selected, history, prefs, saved, environments, activeEnvironmentId } =
-        useStore.getState();
+      const {
+        project,
+        selected,
+        history,
+        prefs,
+        saved,
+        environments,
+        activeEnvironmentId,
+        collapsedNamespaces,
+      } = useStore.getState();
       void writeState({
         project,
         selected,
@@ -245,6 +278,7 @@ export function startPersistence(): void {
         saved,
         environments,
         activeEnvironmentId,
+        collapsedNamespaces,
       } satisfies PersistedState);
     }, PERSIST_DEBOUNCE_MS);
   });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -59,6 +59,20 @@ export interface Preset {
   headers?: Record<string, string>;
 }
 
+/** Sharable config bundle for export/import (one shape for both directions). */
+export interface ConfigBundle {
+  endpoint?: string | null;
+  smdUrl?: string | null;
+  headers?: Record<string, string>;
+  favorites?: string[];
+  saved?: SavedRequest[];
+  savedResponses?: SavedResponse[];
+  environments?: Environment[];
+  idLinks?: Record<string, string>;
+  navbarColor?: string;
+  theme?: Theme;
+}
+
 export type Theme = 'light' | 'dark';
 
 export interface Prefs {
@@ -123,18 +137,7 @@ export interface AppState extends PersistedState {
    * Import a config bundle: connection + favorites + saved + environments +
    * id links + appearance (theme/navbar color), all merged into current state.
    */
-  importConfig(cfg: {
-    endpoint?: string;
-    smdUrl?: string;
-    headers?: Record<string, string>;
-    favorites?: string[];
-    saved?: SavedRequest[];
-    savedResponses?: SavedResponse[];
-    environments?: Environment[];
-    idLinks?: Record<string, string>;
-    navbarColor?: string;
-    theme?: Theme;
-  }): void;
+  importConfig(cfg: ConfigBundle): void;
   /** Save the current project config as a named env (upsert by name) and select it. */
   saveEnvironment(name: string): void;
   applyEnvironment(id: string): void;
@@ -156,6 +159,21 @@ const initialProject: ProjectConfig = {
 };
 
 const initialPrefs: Prefs = { theme: 'light', favorites: [], navbarColor: '' };
+
+/** Returns environments with the active one patched in place (or unchanged). */
+function patchActiveEnv(
+  s: Pick<AppState, 'environments' | 'activeEnvironmentId'>,
+  patch: Partial<Environment>,
+): Environment[] {
+  if (!s.activeEnvironmentId) return s.environments;
+  return s.environments.map((e) => (e.id === s.activeEnvironmentId ? { ...e, ...patch } : e));
+}
+
+/** Effective navbar color: the active env's color, else the global pref. */
+export function selectNavbarColor(s: AppState): string {
+  const env = s.environments.find((e) => e.id === s.activeEnvironmentId);
+  return (env?.color || s.prefs.navbarColor) ?? '';
+}
 
 export const useStore = create<AppState>((set) => ({
   project: initialProject,
@@ -191,14 +209,7 @@ export const useStore = create<AppState>((set) => ({
       const project = { ...s.project, endpoint, headers };
       // Keep the active environment selected and in sync: editing settings
       // updates that env in place instead of silently detaching from it.
-      const environments = s.activeEnvironmentId
-        ? s.environments.map((e) =>
-            e.id === s.activeEnvironmentId
-              ? { ...e, endpoint, headers, smdUrl: project.smdUrl }
-              : e,
-          )
-        : s.environments;
-      return { project, environments };
+      return { project, environments: patchActiveEnv(s, { endpoint, headers, smdUrl: project.smdUrl }) };
     }),
 
   clearProject: () => set({ project: initialProject, selected: null, activeEnvironmentId: null }),
@@ -347,18 +358,13 @@ export const useStore = create<AppState>((set) => ({
     set((s) => ({ prefs: { ...s.prefs, theme: s.prefs.theme === 'dark' ? 'light' : 'dark' } })),
 
   setNavbarColor: (color) =>
-    set((s) => {
+    set((s) =>
       // While an environment is active, color binds to that env (so switching
       // envs changes the navbar); otherwise it sets the global fallback.
-      if (s.activeEnvironmentId) {
-        return {
-          environments: s.environments.map((e) =>
-            e.id === s.activeEnvironmentId ? { ...e, color } : e,
-          ),
-        };
-      }
-      return { prefs: { ...s.prefs, navbarColor: color } };
-    }),
+      s.activeEnvironmentId
+        ? { environments: patchActiveEnv(s, { color }) }
+        : { prefs: { ...s.prefs, navbarColor: color } },
+    ),
 
   toggleFavorite: (name) =>
     set((s) => ({

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -374,6 +374,34 @@ code.sb-type {
   color: var(--sb-color-success);
 }
 
+/* Parameter table: single inlined tree, compact name+type+required cell. */
+.sb-params th:last-child,
+.sb-params td:last-child {
+  width: 40%;
+}
+
+/* Keep the required mark, name and type chip on one line per row. */
+.sb-params td:first-child {
+  white-space: nowrap;
+}
+
+/* Fixed slot so parameter names align whether or not a required mark is shown. */
+.sb-params__req {
+  display: inline-block;
+  width: 16px;
+}
+
+.sb-params__type {
+  margin-left: 8px;
+}
+
+.sb-params__enum {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
 /* JSON viewer */
 .sb-json-viewer__head {
   display: flex;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -554,9 +554,13 @@ code.sb-type {
   margin-top: 16px;
 }
 
-/* Equal-width action buttons, left-aligned so they wrap into a tidy cluster. */
+/* Equal-width action buttons; Try sits left, the rest are pushed right. */
 .sb-actions > .btn {
   min-width: 104px;
+}
+
+.sb-actions > .btn:first-child {
+  margin-right: auto;
 }
 
 /* "From curl" lives by the Form/Raw tabs (it loads a request, not exports one). */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -511,6 +511,18 @@ button.sb-params__caret:hover {
   margin-bottom: 8px;
 }
 
+/* Filter + expand-all/collapse-all row above the JSON tree. */
+.sb-json-viewer__treebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.sb-json-viewer__treebar > .form-control {
+  flex: 1;
+}
+
 /* JSON viewer */
 .sb-json-viewer__head {
   display: flex;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -49,6 +49,16 @@
   background: var(--sb-navbar-line);
 }
 
+/* Narrow screens: collapse the toolbar to icon-only buttons (G4). */
+@media (max-width: 991.98px) {
+  .sb-app__nav .sb-nav-label {
+    display: none;
+  }
+  .sb-app__nav .me-1 {
+    margin-right: 0;
+  }
+}
+
 /* Popups always keep a comfortable minimum height. */
 .modal-body {
   min-height: 180px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -758,6 +758,34 @@ button.sb-params__caret:hover {
   font-weight: 500;
 }
 
+.sb-saved__row {
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+.sb-saved__row:last-child {
+  border-bottom: 0;
+}
+
+.sb-saved__actions {
+  display: flex;
+  gap: 4px;
+}
+
+/* Collapsible request-params / response previews under a saved item. */
+.sb-saved__preview {
+  margin: 0 0 8px 26px;
+  padding: 8px;
+  max-height: 200px;
+  overflow: auto;
+  font-size: 12px;
+  background: var(--bs-tertiary-bg);
+  border-radius: 4px;
+}
+
+.sb-saved__preview-json {
+  margin: 0 0 8px 26px;
+}
+
 @media (max-width: 767px) {
   .sb-app__column {
     max-height: none;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -434,6 +434,57 @@ code.sb-type {
   margin-top: 4px;
 }
 
+/* Linked-field rules editor (Settings). */
+.sb-project__hint-text {
+  font-size: 13px;
+  margin: 4px 0 8px;
+}
+
+.sb-project__link-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.sb-project__link-row > .sb-muted {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+}
+
+/* Inline id links inside the JSON tree (F1). */
+.sb-json-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sb-json-link__btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--sb-color-primary);
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.sb-json-link__btn:hover {
+  color: var(--sb-color-primary-hover);
+}
+
+/* Raw tab toolbar: wrap switch + edit toggle. */
+.sb-json-viewer__rawbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 /* JSON viewer */
 .sb-json-viewer__head {
   display: flex;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -554,13 +554,20 @@ code.sb-type {
   margin-top: 16px;
 }
 
-/* Equal-width action buttons; Try sits left, the rest are pushed right. */
+/* Equal-width action buttons, left-aligned so they wrap into a tidy cluster. */
 .sb-actions > .btn {
   min-width: 104px;
 }
 
-.sb-actions > .btn:first-child {
-  margin-right: auto;
+/* "From curl" lives by the Form/Raw tabs (it loads a request, not exports one). */
+.sb-method-invoker__tabs {
+  position: relative;
+}
+
+.sb-method-invoker__from-curl {
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .sb-method-invoker__loading {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -144,13 +144,16 @@
   padding: 16px;
 }
 
-/* Underline tabs (Form/Raw, Tree/Raw, Input/Output/Error). */
-.sb-app .nav-tabs {
+/* Underline tabs (Form/Raw, Tree/Raw, Input/Output/Error, Saved). Modals are
+   portalled outside .sb-app, so style their tabs too. */
+.sb-app .nav-tabs,
+.modal .nav-tabs {
   gap: 4px;
   border-bottom: 1px solid var(--bs-border-color);
 }
 
-.sb-app .nav-tabs .nav-link {
+.sb-app .nav-tabs .nav-link,
+.modal .nav-tabs .nav-link {
   margin-bottom: -1px;
   padding: 6px 12px;
   border: 0;
@@ -160,12 +163,14 @@
   color: var(--bs-secondary-color);
 }
 
-.sb-app .nav-tabs .nav-link:hover {
+.sb-app .nav-tabs .nav-link:hover,
+.modal .nav-tabs .nav-link:hover {
   color: var(--bs-body-color);
   border-bottom-color: var(--bs-border-color);
 }
 
-.sb-app .nav-tabs .nav-link.active {
+.sb-app .nav-tabs .nav-link.active,
+.modal .nav-tabs .nav-link.active {
   font-weight: 600;
   color: var(--bs-body-color);
   background: transparent;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -163,8 +163,14 @@
 }
 
 /* Sidebar */
+/* Keep the search box pinned while the methods list scrolls under it (G1). */
 .sb-sidebar__search {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   margin-bottom: 12px;
+  padding: 4px 0 8px;
+  background: var(--bs-body-bg);
 }
 
 .sb-sidebar__ns-title {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -578,6 +578,12 @@ code.sb-type {
   margin-top: 4px;
 }
 
+/* The Try-it-out pane is a query container so its actions can shrink to icons
+   when the pane itself is narrow (independent of the viewport width). */
+.sb-method-invoker {
+  container-type: inline-size;
+}
+
 .sb-actions {
   display: flex;
   align-items: center;
@@ -593,6 +599,20 @@ code.sb-type {
 
 .sb-actions > .btn:first-child {
   margin-right: auto;
+}
+
+/* Narrow pane: drop button labels (keep icons + tooltips) so the row fits. */
+@container (max-width: 460px) {
+  .sb-method-invoker .sb-action-label {
+    display: none;
+  }
+  .sb-method-invoker .sb-actions > .btn {
+    min-width: 0;
+  }
+  .sb-method-invoker .sb-actions .me-1,
+  .sb-method-invoker__from-curl .me-1 {
+    margin-right: 0;
+  }
 }
 
 /* "From curl" lives by the Form/Raw tabs (it loads a request, not exports one). */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -325,6 +325,28 @@
   padding-bottom: 12px;
 }
 
+/* Navbar-color presets + custom picker (G6). */
+.sb-project__swatches {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.sb-project__dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  margin-right: 6px;
+  vertical-align: -1px;
+}
+
+.sb-project__color {
+  width: 44px;
+  padding: 2px;
+}
+
 /* Method viewer */
 .sb-method-viewer__title {
   display: flex;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -417,6 +417,27 @@ code.sb-type {
   white-space: nowrap;
 }
 
+/* Collapse/expand toggle (or an equal-width spacer for leaf rows). */
+.sb-params__caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--bs-secondary-color);
+  vertical-align: -2px;
+}
+
+button.sb-params__caret {
+  cursor: pointer;
+}
+
+button.sb-params__caret:hover {
+  color: var(--bs-body-color);
+}
+
 /* Fixed slot so parameter names align whether or not a required mark is shown. */
 .sb-params__req {
   display: inline-block;
@@ -677,11 +698,14 @@ code.sb-type {
   right: 0;
 }
 
+/* Match the result block's separator so Calling -> Response doesn't jump. */
 .sb-method-invoker__loading {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 8px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--bs-border-color);
 }
 
 .sb-history__method {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,11 @@ import react from '@vitejs/plugin-react';
 
 // SMD Box ships as a single self-contained bundle consumed via a plain
 // <script>/<link> pair (currently from jsDelivr). The build therefore targets
-// library/IIFE output with stable, hash-free names: dist/app.js + dist/app.css.
+// library/IIFE output with stable, hash-free names: build/app.js + build/app.css.
+//
+// Output goes to build/ (gitignored), NOT dist/. The committed dist/ is the
+// frozen backward-compatibility bundle served via jsDelivr @latest and is never
+// overwritten by a local `npm run build`; CI publishes Pages from build/.
 //
 // The IIFE `name` below only parks the module namespace on a throwaway global —
 // the real public contract (`window.smdbox`) is assigned explicitly in main.tsx,
@@ -15,7 +19,7 @@ export default defineConfig({
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'production'),
   },
   build: {
-    outDir: 'dist',
+    outDir: 'build',
     emptyOutDir: true,
     cssCodeSplit: false,
     lib: {


### PR DESCRIPTION
Feedback-driven release (**v2.1.0**) — addresses the first round of user feedback.

### Onboarding & config
- Enter on a single Accept click; show progress while the schema validates.
- Import config and an optional knowledge-base link in the navbar; one-click setup presets via `window.smdbox({ presets })`.

### Method docs
- Render parameters as one flat table with nested types expanded inline (collapsible), a type badge and required mark per field, and enum values; show concrete type names instead of `object`.

### Try it out
- Type-based input placeholders; paste a `curl` command to build the request (auto-detected in Raw, plus a "From curl" modal).

### Response
- Link out from id fields and URL-valued fields (open / copy); id rules via `window.smdbox({ idLinks })` + a Settings editor.
- Edit the raw response in place (for mocks); save responses.
- Expand all / collapse all; tree expansion persists across re-runs.

### Saved & environments
- Saved requests: reorder, rename, params preview; a Responses tab.
- Rename environments; editing settings keeps the active env in sync (no duplicate on "Save current as…").
- Per-environment navbar color (DEV/PROD presets or custom) to tell environments apart.

### Layout & theme
- Responsive: panes stack below `lg`, the toolbar collapses to icons on narrow screens, the params table scrolls instead of overlapping the neighbour; sticky sidebar search; persisted collapse state.

### Config import/export
- One bundle covers connection, favorites, saved requests & responses, environments (+ colors), id-link rules, theme and navbar color.

### Build / internals
- `npm run build` now outputs to `build/`; the committed `dist/` stays the frozen legacy jsDelivr bundle (CI publishes Pages from `build/`).
- Shared `useSetToggle` / `CollapseCaret` / `selectNavbarColor`; unit tests for the curl parser and id-link rules.

_Out of scope: **E1** (methods returning `null` is a zenrpc / back-end concern)._
