### PR TITLE
Resizable layout panes and required-field markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smdbox",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "UI for human-readable JSON-RPC SMD schemas: browse methods and call them live.",
   "repository": "https://github.com/vmkteam/smdbox",
   "license": "MIT",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,12 +3,10 @@ import {
   Alert,
   Button,
   ButtonGroup,
-  Col,
   Container,
   Dropdown,
   Modal,
   Navbar,
-  Row,
   Spinner,
 } from 'react-bootstrap';
 import {
@@ -29,9 +27,11 @@ import {
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { History } from '../components/History';
 import { MethodViewer } from '../components/MethodViewer';
+import { PaneResizer } from '../components/PaneResizer';
 import { Project } from '../components/Project';
 import { Saved } from '../components/Saved';
 import { Sidebar } from '../components/Sidebar';
+import { usePaneWidth } from '../hooks/usePaneWidth';
 import { refreshSmd, useSmd } from '../data/queries';
 import { selectNavbarColor, useStore } from '../store/store';
 import { useMethodHash } from './useMethodHash';
@@ -69,6 +69,18 @@ function Workspace() {
   const [showSettings, setShowSettings] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [showSaved, setShowSaved] = useState(false);
+
+  // Draggable divider between the methods list and the main pane.
+  const [sidebarW, setSidebarW, resetSidebarW] = usePaneWidth('sidebar');
+  const mainSplitRef = useRef<HTMLDivElement>(null);
+  const onSidebarResize = useCallback(
+    (w: number) => {
+      const total = mainSplitRef.current?.clientWidth ?? 0;
+      // Keep the list usable and leave the main pane at least 420px.
+      setSidebarW(Math.max(200, Math.min(w, total - 420)));
+    },
+    [setSidebarW],
+  );
 
   // Scope the Bootstrap theme to the whole document (covers portalled modals).
   useEffect(() => {
@@ -255,14 +267,19 @@ function Workspace() {
             </Alert>
           )}
           {services && (
-            <Row>
-              <Col md={3} className="sb-app__column">
+            <div
+              className="sb-split sb-split--app"
+              ref={mainSplitRef}
+              style={sidebarW != null ? ({ '--sb-sidebar-w': `${sidebarW}px` } as React.CSSProperties) : undefined}
+            >
+              <div className="sb-split__pane sb-split__pane--sidebar sb-app__column">
                 <Sidebar services={services} />
-              </Col>
-              <Col md={9} className="sb-app__column">
+              </div>
+              <PaneResizer label="Resize methods list" onResize={onSidebarResize} onReset={resetSidebarW} />
+              <div className="sb-split__pane sb-split__pane--main sb-app__column">
                 <MethodViewer services={services} />
-              </Col>
-            </Row>
+              </div>
+            </div>
           )}
 
           <Modal show={showSettings} onHide={() => setShowSettings(false)}>

--- a/src/components/FormFromSchema.tsx
+++ b/src/components/FormFromSchema.tsx
@@ -5,6 +5,7 @@ import { ariaDescribedByIds, examplesId, getInputProps, getTemplate, getUiOption
 import type {
   ArrayFieldTemplateProps,
   BaseInputTemplateProps,
+  FieldTemplateProps,
   IconButtonProps,
   RJSFSchema,
 } from '@rjsf/utils';
@@ -150,6 +151,66 @@ function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
   );
 }
 
+// Mirrors @rjsf/react-bootstrap's FieldTemplate, but renders the required marker
+// as a prominent red asterisk after the label so the Try-it-out form makes clear
+// which params must be filled. "Required" follows the SMD `optional` flag
+// (required unless `optional` is truthy), matching the documentation table — the
+// SMD→JSON Schema conversion carries `optional` rather than a `required` array.
+function FieldTemplate(props: FieldTemplateProps) {
+  const {
+    id, children, displayLabel, rawErrors = [], errors, help, description, rawDescription,
+    classNames, style, disabled, label, hidden, onKeyRename, onKeyRenameBlur,
+    onRemoveProperty, readonly, required, schema, uiSchema, registry,
+  } = props;
+  const uiOptions = getUiOptions(uiSchema);
+  const WrapIfAdditionalTemplate = getTemplate('WrapIfAdditionalTemplate', registry, uiOptions);
+  if (hidden) {
+    return <div className="hidden">{children}</div>;
+  }
+  const isCheckbox = uiOptions.widget === 'checkbox';
+  const isRequired = !(schema as { optional?: boolean }).optional;
+  return (
+    <WrapIfAdditionalTemplate
+      classNames={classNames}
+      style={style}
+      disabled={disabled}
+      id={id}
+      label={label}
+      displayLabel={displayLabel}
+      rawDescription={rawDescription}
+      onKeyRename={onKeyRename}
+      onKeyRenameBlur={onKeyRenameBlur}
+      onRemoveProperty={onRemoveProperty}
+      readonly={readonly}
+      required={required}
+      schema={schema}
+      uiSchema={uiSchema}
+      registry={registry}
+    >
+      <BsForm.Group>
+        {displayLabel && !isCheckbox && (
+          <BsForm.Label htmlFor={id} className={rawErrors.length > 0 ? 'text-danger' : ''}>
+            {label}
+            {isRequired && (
+              <span className="sb-required-star" aria-label="required" title="required">
+                *
+              </span>
+            )}
+          </BsForm.Label>
+        )}
+        {children}
+        {displayLabel && rawDescription && !isCheckbox && (
+          <BsForm.Text className={rawErrors.length > 0 ? 'text-danger' : 'text-muted'}>
+            {description}
+          </BsForm.Text>
+        )}
+        {errors}
+        {help}
+      </BsForm.Group>
+    </WrapIfAdditionalTemplate>
+  );
+}
+
 interface FormFromSchemaProps {
   schema: JsonSchema;
   formData: Record<string, unknown>;
@@ -180,7 +241,7 @@ export function FormFromSchema({ schema, formData, onChange, onSubmit, actions }
         schema={formSchema as RJSFSchema}
         formData={formData}
         validator={validator}
-        templates={{ ButtonTemplates: buttonTemplates, ArrayFieldTemplate, BaseInputTemplate }}
+        templates={{ ButtonTemplates: buttonTemplates, ArrayFieldTemplate, BaseInputTemplate, FieldTemplate }}
         onChange={(e) => onChange(e.formData as Record<string, unknown>)}
         onSubmit={(e) => onSubmit(e.formData as Record<string, unknown>)}
         onError={(errors) => console.error(errors)}

--- a/src/components/MethodViewer.tsx
+++ b/src/components/MethodViewer.tsx
@@ -1,12 +1,14 @@
-import { useMemo, useState } from 'react';
-import { Alert, Button, Col, Row } from 'react-bootstrap';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Alert, Button } from 'react-bootstrap';
 import { Eye, EyeSlash } from 'react-bootstrap-icons';
 
+import { usePaneWidth } from '../hooks/usePaneWidth';
 import { smdToJsonSchema } from '../lib/smdToJsonSchema';
 import { useStore } from '../store/store';
 import type { SmdService } from '../types/smd';
 import { MethodDescription } from './MethodDescription';
 import { MethodInvoker } from './MethodInvoker';
+import { PaneResizer } from './PaneResizer';
 
 /** Main pane: documentation and try-it-out for the selected method. */
 export function MethodViewer({ services }: { services: Record<string, SmdService> }) {
@@ -14,6 +16,18 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
   const { endpoint, headers } = useStore((s) => s.project);
   const [showInfo, setShowInfo] = useState(true);
   const [showTry, setShowTry] = useState(true);
+
+  // Draggable divider between the documentation and the try-it-out panes.
+  const [docW, setDocW, resetDocW] = usePaneWidth('mv-doc');
+  const splitRef = useRef<HTMLDivElement>(null);
+  const onDocResize = useCallback(
+    (w: number) => {
+      const total = splitRef.current?.clientWidth ?? 0;
+      // Keep both panes usable: documentation >= 280px, try-it-out >= 320px.
+      setDocW(Math.max(280, Math.min(w, total - 320)));
+    },
+    [setDocW],
+  );
 
   const service = selected ? services[selected] : undefined;
   const schema = useMemo(() => (service ? smdToJsonSchema(service) : null), [service]);
@@ -26,11 +40,19 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
     );
   }
 
+  const bothShown = showInfo && showTry;
+
   return (
     <div className="sb-method-viewer">
-      <Row>
+      <div
+        className={`sb-split sb-split--mv${bothShown ? '' : ' sb-split--single'}`}
+        ref={splitRef}
+        style={
+          bothShown && docW != null ? ({ '--sb-doc-w': `${docW}px` } as React.CSSProperties) : undefined
+        }
+      >
         {showInfo && (
-          <Col xs={12} lg={showTry ? 7 : 12}>
+          <div className="sb-split__pane sb-split__pane--doc">
             <h3 className="sb-method-viewer__title">
               {selected}
               {showTry ? (
@@ -56,11 +78,15 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
               )}
             </h3>
             <MethodDescription service={service} />
-          </Col>
+          </div>
+        )}
+
+        {bothShown && (
+          <PaneResizer label="Resize documentation" onResize={onDocResize} onReset={resetDocW} />
         )}
 
         {showTry && (
-          <Col xs={12} lg={showInfo ? 5 : 12}>
+          <div className="sb-split__pane sb-split__pane--try">
             <h3 className="sb-method-viewer__title">
               Try it out
               {showInfo ? (
@@ -92,9 +118,9 @@ export function MethodViewer({ services }: { services: Record<string, SmdService
               endpoint={endpoint}
               headers={headers}
             />
-          </Col>
+          </div>
         )}
-      </Row>
+      </div>
     </div>
   );
 }

--- a/src/components/PaneResizer.tsx
+++ b/src/components/PaneResizer.tsx
@@ -1,0 +1,53 @@
+import { useRef, type PointerEvent } from 'react';
+
+interface PaneResizerProps {
+  /** Called during the drag with the left pane's new pixel width (unclamped). */
+  onResize: (width: number) => void;
+  /** Called on double-click to restore the default width. */
+  onReset?: () => void;
+  /** Accessible label, e.g. "Resize methods list". */
+  label: string;
+}
+
+/**
+ * A vertical drag handle that sits between two flex panes. It resizes the pane
+ * immediately to its left (its previous sibling), reporting that pane's new
+ * pixel width to the parent — which clamps and persists it (see usePaneWidth).
+ * Double-click resets to the default. Hidden on stacked (narrow) layouts via CSS.
+ */
+export function PaneResizer({ onResize, onReset, label }: PaneResizerProps) {
+  const start = useRef<{ x: number; w: number } | null>(null);
+
+  const onPointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    const pane = e.currentTarget.previousElementSibling as HTMLElement | null;
+    if (!pane) return;
+    start.current = { x: e.clientX, w: pane.getBoundingClientRect().width };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  };
+
+  const onPointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    if (!start.current) return;
+    onResize(start.current.w + (e.clientX - start.current.x));
+  };
+
+  const onPointerUp = (e: PointerEvent<HTMLDivElement>) => {
+    if (!start.current) return;
+    start.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+  };
+
+  return (
+    <div
+      className="sb-pane-resizer"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      title="Drag to resize · double-click to reset"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onDoubleClick={onReset}
+    />
+  );
+}

--- a/src/hooks/usePaneWidth.ts
+++ b/src/hooks/usePaneWidth.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react';
+
+const PREFIX = 'smdbox:pane:';
+
+function load(key: string): number | null {
+  try {
+    const raw = localStorage.getItem(PREFIX + key);
+    if (raw !== null) {
+      const n = Number(raw);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+  } catch {
+    // localStorage unavailable (private mode / quota) — fall back to the CSS default.
+  }
+  return null;
+}
+
+function persist(key: string, width: number): void {
+  try {
+    localStorage.setItem(PREFIX + key, String(Math.round(width)));
+  } catch {
+    // Ignore quota / availability errors — resizing still works in-session.
+  }
+}
+
+function clear(key: string): void {
+  try {
+    localStorage.removeItem(PREFIX + key);
+  } catch {
+    // Ignore — nothing persisted to remove.
+  }
+}
+
+export type PaneWidth = [
+  /** Pixel width set by the user, or null while the CSS default applies. */
+  width: number | null,
+  /** Set (and persist) the pixel width. */
+  setWidth: (px: number) => void,
+  /** Clear (and persist) back to the CSS default. */
+  reset: () => void,
+];
+
+/**
+ * A draggable pane's width in pixels, persisted to localStorage under `key`.
+ * Returns `null` until the user resizes, so a CSS fallback width can apply
+ * (and stay responsive) out of the box.
+ */
+export function usePaneWidth(key: string): PaneWidth {
+  const [width, setWidth] = useState<number | null>(() => load(key));
+
+  const set = useCallback(
+    (px: number) => {
+      setWidth(px);
+      persist(key, px);
+    },
+    [key],
+  );
+
+  const reset = useCallback(() => {
+    setWidth(null);
+    clear(key);
+  }, [key]);
+
+  return [width, set, reset];
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -137,6 +137,102 @@
   overflow-y: auto;
 }
 
+/* Resizable split panes: sidebar | main (app) and documentation | try-it-out
+   (method viewer). Each draggable pane gets a width from a CSS variable set
+   inline once the user resizes; the fallback keeps the default proportions. */
+.sb-split {
+  display: flex;
+  align-items: stretch;
+}
+
+.sb-split__pane {
+  min-width: 0; /* allow panes to shrink below their content width */
+}
+
+.sb-split--app > .sb-split__pane--sidebar {
+  flex: 0 0 var(--sb-sidebar-w, 25%);
+}
+
+.sb-split--app > .sb-split__pane--main {
+  flex: 1 1 0;
+  padding-left: 12px;
+}
+
+.sb-split--mv > .sb-split__pane--doc {
+  flex: 0 0 var(--sb-doc-w, 58%);
+  padding-right: 12px;
+}
+
+.sb-split--mv > .sb-split__pane--try {
+  flex: 1 1 0;
+  padding-left: 12px;
+}
+
+/* Only one pane shown (eye toggle): it spans the full width. */
+.sb-split--single > .sb-split__pane {
+  flex: 1 1 auto;
+}
+
+/* The drag handle: a slim always-visible divider that brightens on hover. */
+.sb-pane-resizer {
+  position: relative;
+  flex: 0 0 11px;
+  cursor: col-resize;
+  user-select: none;
+  touch-action: none;
+}
+
+.sb-pane-resizer::after {
+  content: '';
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 50%;
+  width: 2px;
+  border-radius: 1px;
+  background: transparent; /* invisible until hovered */
+  transform: translateX(-50%);
+}
+
+.sb-pane-resizer:hover::after,
+.sb-pane-resizer:active::after {
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--sb-color-primary);
+}
+
+/* Narrow screens: stack the app split (matches the old md grid) and drop the handle. */
+@media (max-width: 767.98px) {
+  .sb-split--app {
+    flex-direction: column;
+  }
+  .sb-split--app > .sb-split__pane {
+    flex: 0 0 auto;
+    width: auto;
+    padding-left: 0;
+  }
+  .sb-split--app > .sb-pane-resizer {
+    display: none;
+  }
+}
+
+/* Stack documentation over try-it-out below lg (matches the old lg grid). */
+@media (max-width: 991.98px) {
+  .sb-split--mv {
+    flex-direction: column;
+  }
+  .sb-split--mv > .sb-split__pane {
+    flex: 0 0 auto;
+    width: auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .sb-split--mv > .sb-pane-resizer {
+    display: none;
+  }
+}
+
 .sb-app__loading {
   display: flex;
   align-items: center;
@@ -409,6 +505,13 @@ code.sb-type {
 
 .sb-required {
   color: var(--sb-color-success);
+}
+
+/* Red asterisk marking required params in the Try-it-out form. */
+.sb-required-star {
+  margin-left: 2px;
+  color: var(--sb-color-danger);
+  font-weight: 600;
 }
 
 /* Parameter table: single inlined tree, compact name+type+required cell. */


### PR DESCRIPTION
## Summary

UX follow-ups for the v2 UI (bumps version to **2.1.1**):

- **Required-field markers** — required params now show a red asterisk
  after the label in the *Try it out* form, so it's clear what must be
  filled. Driven by the SMD `optional` flag (mirrors the docs table); no
  validation/submit behaviour change.
- **Resizable layout** — two draggable dividers in the main workspace:
  *methods list ↔ documentation* and *documentation ↔ Try it out*.
  Widths persist to `localStorage` (`smdbox:pane:*`), have sensible min
  clamps, and the layout stacks (dividers hidden) on narrow screens.
  Dividers are invisible by default and highlight on hover.

## Implementation

- `FormFromSchema.tsx` — custom rjsf `FieldTemplate` rendering the red
  asterisk (`.sb-required-star`).
- New `PaneResizer.tsx` (pointer-capture drag handle) + `usePaneWidth.ts`
  (localStorage-backed width). Wired into `App.tsx` (sidebar↔main) and
  `MethodViewer.tsx` (docs↔try), replacing the Bootstrap grid columns
  with a flex split + responsive media queries.

## Verification

- `tsc --noEmit`, `eslint`, `vitest` (65 tests), `vite build` — all green.
- Playwright (Chromium + WebKit): both dividers drag and persist, the
  asterisk shows only on required params, and panes stack on narrow
  viewports.

`dist/` is untouched (frozen legacy bundle); build output goes to `build/`.